### PR TITLE
QOS v5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,9 @@ node_modules/
 *.sublime-project
 *.sublime-workspace
 
+# CPU profiles
+cpu-profiles/
+
 # New Relic
 newrelic_app.log
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,29 @@
+## 5.0.0
+
+This release is about simplifying options, improved performance, and
+predictable results (less "magic").
+
+- **Breaking** `maxHostRate` option work the similar as before,
+  but now require `minHostRate` to be set as well so that rate
+  limiting is based on the lag ratio between `minLag` and `maxLag`.
+  Additionally host rate limiting is enabled by default
+- **Breaking** `maxIpRate` option work the similar as before,
+  but now require `minIpRate` to be set as well so that rate
+  limiting is based on the lag ratio between `minLag` and `maxLag`.
+  IP rate limiting remains disabled by default
+- **Breaking** `behindProxy` has been replaced with `httpBehindProxy`
+  and `httpsBehindProxy` to account for possible differences between
+  bindings
+- **Breaking** `exemptLocalAddress` has been removed in favor
+  of existing whitelisting. This "feature" was highly flawed and
+  could potentially flag any internal NAT addresses as exempt when
+  the intention is really only to exempt the immediate host
+- **Breaking** All `Threshold` options have been removed blocking
+  has shifted entirely to rate limiting via `minHostRate` and
+  `minIpRate`. Additionally minimum request options have been
+  removed, but rate limiting now must meet `minHostRate` or
+  `minIpRate`
+
 ## 4.1.1
 
 - **Debug** Expose `id` property on cache items and export utils

--- a/README.md
+++ b/README.md
@@ -2,9 +2,10 @@
 
 [![NPM](https://nodei.co/npm/connect-qos.png?mini=true)](https://nodei.co/npm/connect-qos/) [![Build Status](https://app.travis-ci.com/godaddy/connect-qos.svg?branch=main)](https://app.travis-ci.com/godaddy/connect-qos)
 
-Connect middleware that **helps** maintain a high quality of service during heavy traffic. The basic
-idea is to identify bad actors and not penalize legitimate traffic more than necessary until
-proper mitigation can be activated.
+Connect middleware that **helps** maintain a high quality of service
+during heavy traffic. The basic idea is to identify bad actors and
+not penalize legitimate traffic more than necessary until proper
+mitigation can be activated.
 
 
 ## Warning
@@ -78,37 +79,24 @@ For you tweakers out there, here's some levers to pull:
   Default should typically suffice unless you support cpu-intensive operations.
 * **maxLag** (default: `300`) - The highest lag threshold which will block the
   greatest amount of traffic determined by `maxBadHostThreshold` or `maxBadIpThreshold`.
-* **minBadHostThreshold** (default: `0.50`) - At `minLag` the fewest number of hosts
-  will be blocked. If a host equates to 50%+ of the traffic,
-	then that 50%+ will be blocked even at `minLag`.
-* **maxBadHostThreshold** (default: `0.01`) - At `maxLag` hosts will be blocked
-  if they meet or exceed 1% (by default) of all traffic.
-* **minBadIpThreshold** (default: `0.50`) - At `minLag` the fewest number of IPs
-  will be blocked. If a IP equates to 50% of the traffic,
-	then that 50% will be blocked even at `minLag`.
-* **maxBadIpThreshold** (default: `0.01`) - At `maxLag` IPs will be blocked
-  if they meet or exceed 1% (by default) of all traffic.
-* **minHostRequests** (default: `30`) - Minimum amount of host requests before
-  sufficient history to allow blocking biggest hitters if under load (>= `minLag`).
-	You can disable host monitoring by setting this to `false`.
-* **minIpRequests** (default: `100`) - Minimum amount of IP requests before
-  sufficient history to allow blocking biggest hitters if under load (>= `minLag`).
-	You can disable IP monitoring by setting this to `false`.
-* **maxHostRate** (default: `0`) - If non-zero and no lag bad actors will be
-  flagged by rate limiting instead.
-* **maxIpRate** (default: `0`) - If non-zero and no lag bad actors will be
-  flagged by rate limiting instead.
+* **minHostRate** (default: `20`) - Minimum rate if lag is >= maxLag. Disable
+  rate limiting by setting to `0`.
+* **maxHostRate** (default: `40`) - Maximum rate if lag is <= minLag.
+* **minIpRate** (default: `0`) - Minimum rate if lag is >= maxLag. Disable
+  rate limiting by setting to `0`.
+* **maxIpRate** (default: `0`) - Maximum rate if lag is <= minLag.
 * **errorStatusCode** (default: `503`) - The HTTP status code to return if the
   request has been throttled.
-* **exemptLocalAddress** (default: `true`) - By default local requests are exempt
-  from QOS. This is beneficial for local testing, but critical for services that
-	rely on healthchecks.
-* **historySize** (default: `300`) - The LRU history size to use in
+* **historySize** (default: `200`) - The LRU history size to use in
   tracking bad actors. Hosts and IPs both get their own dedicated LRU.
 * **maxAge** (default: `10000`) - Time (in ms) before history is purged.
-* **hostWhitelist** `Set<string>(['localhost', 'localhost:8080'])` - If provided will never flag hosts as bad actors.
+  10 seconds is generally more than adequate to capture an accurate hit rate.
+* **hostWhitelist** `Set<string>(['localhost'])` - If provided will never
+  flag hosts as bad actors.
 * **ipWhitelist** `Set<string>([])` - If provided will never flag IPs as bad actors.
-* **behindProxy** (default: `false`) - `x-forwarded-for` header only supported
+* **httpBehindProxy** (default: `false`) - `x-forwarded-for` header only supported
+  if this option is set to `true`.
+* **httpsBehindProxy** (default: `false`) - `x-forwarded-for` header only supported
   if this option is set to `true`.
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -59,29 +59,29 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.19.0",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.19.0.tgz",
-      "integrity": "sha512-y5rqgTTPTmaF5e2nVhOxw+Ur9HDJLsWb6U/KpgUzRZEdPfE6VOubXBKLdbcUTijzRptednSBDQbYZBOSqJxpJw==",
+      "version": "7.19.1",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.19.1.tgz",
+      "integrity": "sha512-72a9ghR0gnESIa7jBN53U32FOVCEoztyIlKaNoU05zRhEecduGK9L9c3ww7Mp06JiR+0ls0GBPFJQwwtjn9ksg==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.19.0",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.19.0.tgz",
-      "integrity": "sha512-reM4+U7B9ss148rh2n1Qs9ASS+w94irYXga7c2jaQv9RVzpS7Mv1a9rnYYwuDa45G+DkORt9g6An2k/V4d9LbQ==",
+      "version": "7.19.1",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.19.1.tgz",
+      "integrity": "sha512-1H8VgqXme4UXCRv7/Wa1bq7RVymKOzC7znjyFM8KiEzwFqcKUKYNoQef4GhdklgNvoBXyW4gYhuBNCM5o1zImw==",
       "dev": true,
       "dependencies": {
         "@ampproject/remapping": "^2.1.0",
         "@babel/code-frame": "^7.18.6",
         "@babel/generator": "^7.19.0",
-        "@babel/helper-compilation-targets": "^7.19.0",
+        "@babel/helper-compilation-targets": "^7.19.1",
         "@babel/helper-module-transforms": "^7.19.0",
         "@babel/helpers": "^7.19.0",
-        "@babel/parser": "^7.19.0",
+        "@babel/parser": "^7.19.1",
         "@babel/template": "^7.18.10",
-        "@babel/traverse": "^7.19.0",
+        "@babel/traverse": "^7.19.1",
         "@babel/types": "^7.19.0",
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
@@ -126,14 +126,14 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.19.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.19.0.tgz",
-      "integrity": "sha512-Ai5bNWXIvwDvWM7njqsG3feMlL9hCVQsPYXodsZyLwshYkZVJt59Gftau4VrE8S9IT9asd2uSP1hG6wCNw+sXA==",
+      "version": "7.19.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.19.1.tgz",
+      "integrity": "sha512-LlLkkqhCMyz2lkQPvJNdIYU7O5YjWRgC2R4omjCTpZd8u8KMQzZvX4qce+/BluN1rcQiV7BoGUpmQ0LeHerbhg==",
       "dev": true,
       "dependencies": {
-        "@babel/compat-data": "^7.19.0",
+        "@babel/compat-data": "^7.19.1",
         "@babel/helper-validator-option": "^7.18.6",
-        "browserslist": "^4.20.2",
+        "browserslist": "^4.21.3",
         "semver": "^6.3.0"
       },
       "engines": {
@@ -251,9 +251,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.18.6.tgz",
-      "integrity": "sha512-MmetCkz9ej86nJQV+sFCxoGGrUbU3q02kgLciwkrt9QqEB7cP39oKEY0PakknEO0Gu20SskMRi+AYZ3b1TpN9g==",
+      "version": "7.19.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz",
+      "integrity": "sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
@@ -368,9 +368,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.19.0",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.19.0.tgz",
-      "integrity": "sha512-74bEXKX2h+8rrfQUfsBfuZZHzsEs6Eql4pqy/T4Nn6Y9wNPggQOqD6z6pn5Bl8ZfysKouFZT/UXEH94ummEeQw==",
+      "version": "7.19.1",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.19.1.tgz",
+      "integrity": "sha512-h7RCSorm1DdTVGJf3P2Mhj3kdnkmF/EiysUkzS2TdgAYqyjFdMQJbVuXOBej2SBJaXan/lIVtT6KkGbyyq753A==",
       "dev": true,
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -556,9 +556,9 @@
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.19.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.19.0.tgz",
-      "integrity": "sha512-4pKpFRDh+utd2mbRC8JLnlsMUii3PMHjpL6a0SZ4NMZy7YFP9aXORxEhdMVOc9CpWtDF09IkciQLEhK7Ml7gRA==",
+      "version": "7.19.1",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.19.1.tgz",
+      "integrity": "sha512-0j/ZfZMxKukDaag2PtOPDbwuELqIar6lLskVPPJDjXMXjfLb1Obo/1yjxIGqqAJrmfaTIY3z2wFLAQ7qSkLsuA==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.18.6",
@@ -567,7 +567,7 @@
         "@babel/helper-function-name": "^7.19.0",
         "@babel/helper-hoist-variables": "^7.18.6",
         "@babel/helper-split-export-declaration": "^7.18.6",
-        "@babel/parser": "^7.19.0",
+        "@babel/parser": "^7.19.1",
         "@babel/types": "^7.19.0",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
@@ -1042,9 +1042,9 @@
       }
     },
     "node_modules/@sinclair/typebox": {
-      "version": "0.24.41",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.24.41.tgz",
-      "integrity": "sha512-TJCgQurls4FipFvHeC+gfAzb+GGstL0TDwYJKQVtTeSvJIznWzP7g3bAd5gEBlr8+bIxqnWS9VGVWREDhmE8jA==",
+      "version": "0.24.42",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.24.42.tgz",
+      "integrity": "sha512-d+2AtrHGyWek2u2ITF0lHRIv6Tt7X0dEHW+0rP+5aDCEjC3fiN2RBjrLD0yU0at52BcZbRGxLbAtXiR0hFCjYw==",
       "dev": true
     },
     "node_modules/@sinonjs/commons": {
@@ -1287,9 +1287,9 @@
       }
     },
     "node_modules/@swc/core-linux-x64-gnu": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.3.0.tgz",
-      "integrity": "sha512-Ds76Lu7vfE01rgFcf9O1OuNBwQSHBpGwGOKGnwob6T2SCR4DBQz4MD0jLw/tdCZGR8x7NVMteBzQAp3CsUORZw==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.3.1.tgz",
+      "integrity": "sha512-gNojY1qIKksK9kNdY4pqrlUILTxfqSWtXjX0qV2mlxgwRpnOATJnMx585q09cOZnkN2/QB+33pXnT8z/wxuGzQ==",
       "cpu": [
         "x64"
       ],
@@ -1781,9 +1781,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.21.3",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.3.tgz",
-      "integrity": "sha512-898rgRXLAyRkM1GryrrBHGkqA5hlpkV5MhtZwg9QXeiyLUYs2k00Un05aX5l2/yJIOObYKOpS2JNo8nJDE7fWQ==",
+      "version": "4.21.4",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.4.tgz",
+      "integrity": "sha512-CBHJJdDmgjl3daYjN5Cp5kbTf1mUhZoS+beLklHIvkOWscs83YAhLlF3Wsh/lciQYAcbBJgTOD44VtG31ZM4Hw==",
       "dev": true,
       "funding": [
         {
@@ -1796,10 +1796,10 @@
         }
       ],
       "dependencies": {
-        "caniuse-lite": "^1.0.30001370",
-        "electron-to-chromium": "^1.4.202",
+        "caniuse-lite": "^1.0.30001400",
+        "electron-to-chromium": "^1.4.251",
         "node-releases": "^2.0.6",
-        "update-browserslist-db": "^1.0.5"
+        "update-browserslist-db": "^1.0.9"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -1854,9 +1854,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001399",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001399.tgz",
-      "integrity": "sha512-4vQ90tMKS+FkvuVWS5/QY1+d805ODxZiKFzsU8o/RsVJz49ZSRR8EjykLJbqhzdPgadbX6wB538wOzle3JniRA==",
+      "version": "1.0.30001402",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001402.tgz",
+      "integrity": "sha512-Mx4MlhXO5NwuvXGgVb+hg65HZ+bhUYsz8QtDGDo2QmaJS2GBX47Xfi2koL86lc8K+l+htXeTEB/Aeqvezoo6Ew==",
       "dev": true,
       "funding": [
         {
@@ -2082,9 +2082,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.248",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.248.tgz",
-      "integrity": "sha512-qShjzEYpa57NnhbW2K+g+Fl+eNoDvQ7I+2MRwWnU6Z6F0HhXekzsECCLv+y2OJUsRodjqoSfwHkIX42VUFtUzg==",
+      "version": "1.4.254",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.254.tgz",
+      "integrity": "sha512-Sh/7YsHqQYkA6ZHuHMy24e6TE4eX6KZVsZb9E/DvU1nQRIrH4BflO/4k+83tfdYvDl+MObvlqHPRICzEdC9c6Q==",
       "dev": true
     },
     "node_modules/emittery": {
@@ -4385,26 +4385,26 @@
       }
     },
     "@babel/compat-data": {
-      "version": "7.19.0",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.19.0.tgz",
-      "integrity": "sha512-y5rqgTTPTmaF5e2nVhOxw+Ur9HDJLsWb6U/KpgUzRZEdPfE6VOubXBKLdbcUTijzRptednSBDQbYZBOSqJxpJw==",
+      "version": "7.19.1",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.19.1.tgz",
+      "integrity": "sha512-72a9ghR0gnESIa7jBN53U32FOVCEoztyIlKaNoU05zRhEecduGK9L9c3ww7Mp06JiR+0ls0GBPFJQwwtjn9ksg==",
       "dev": true
     },
     "@babel/core": {
-      "version": "7.19.0",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.19.0.tgz",
-      "integrity": "sha512-reM4+U7B9ss148rh2n1Qs9ASS+w94irYXga7c2jaQv9RVzpS7Mv1a9rnYYwuDa45G+DkORt9g6An2k/V4d9LbQ==",
+      "version": "7.19.1",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.19.1.tgz",
+      "integrity": "sha512-1H8VgqXme4UXCRv7/Wa1bq7RVymKOzC7znjyFM8KiEzwFqcKUKYNoQef4GhdklgNvoBXyW4gYhuBNCM5o1zImw==",
       "dev": true,
       "requires": {
         "@ampproject/remapping": "^2.1.0",
         "@babel/code-frame": "^7.18.6",
         "@babel/generator": "^7.19.0",
-        "@babel/helper-compilation-targets": "^7.19.0",
+        "@babel/helper-compilation-targets": "^7.19.1",
         "@babel/helper-module-transforms": "^7.19.0",
         "@babel/helpers": "^7.19.0",
-        "@babel/parser": "^7.19.0",
+        "@babel/parser": "^7.19.1",
         "@babel/template": "^7.18.10",
-        "@babel/traverse": "^7.19.0",
+        "@babel/traverse": "^7.19.1",
         "@babel/types": "^7.19.0",
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
@@ -4438,14 +4438,14 @@
       }
     },
     "@babel/helper-compilation-targets": {
-      "version": "7.19.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.19.0.tgz",
-      "integrity": "sha512-Ai5bNWXIvwDvWM7njqsG3feMlL9hCVQsPYXodsZyLwshYkZVJt59Gftau4VrE8S9IT9asd2uSP1hG6wCNw+sXA==",
+      "version": "7.19.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.19.1.tgz",
+      "integrity": "sha512-LlLkkqhCMyz2lkQPvJNdIYU7O5YjWRgC2R4omjCTpZd8u8KMQzZvX4qce+/BluN1rcQiV7BoGUpmQ0LeHerbhg==",
       "dev": true,
       "requires": {
-        "@babel/compat-data": "^7.19.0",
+        "@babel/compat-data": "^7.19.1",
         "@babel/helper-validator-option": "^7.18.6",
-        "browserslist": "^4.20.2",
+        "browserslist": "^4.21.3",
         "semver": "^6.3.0"
       }
     },
@@ -4530,9 +4530,9 @@
       "dev": true
     },
     "@babel/helper-validator-identifier": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.18.6.tgz",
-      "integrity": "sha512-MmetCkz9ej86nJQV+sFCxoGGrUbU3q02kgLciwkrt9QqEB7cP39oKEY0PakknEO0Gu20SskMRi+AYZ3b1TpN9g==",
+      "version": "7.19.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz",
+      "integrity": "sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==",
       "dev": true
     },
     "@babel/helper-validator-option": {
@@ -4622,9 +4622,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.19.0",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.19.0.tgz",
-      "integrity": "sha512-74bEXKX2h+8rrfQUfsBfuZZHzsEs6Eql4pqy/T4Nn6Y9wNPggQOqD6z6pn5Bl8ZfysKouFZT/UXEH94ummEeQw==",
+      "version": "7.19.1",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.19.1.tgz",
+      "integrity": "sha512-h7RCSorm1DdTVGJf3P2Mhj3kdnkmF/EiysUkzS2TdgAYqyjFdMQJbVuXOBej2SBJaXan/lIVtT6KkGbyyq753A==",
       "dev": true
     },
     "@babel/plugin-syntax-async-generators": {
@@ -4756,9 +4756,9 @@
       }
     },
     "@babel/traverse": {
-      "version": "7.19.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.19.0.tgz",
-      "integrity": "sha512-4pKpFRDh+utd2mbRC8JLnlsMUii3PMHjpL6a0SZ4NMZy7YFP9aXORxEhdMVOc9CpWtDF09IkciQLEhK7Ml7gRA==",
+      "version": "7.19.1",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.19.1.tgz",
+      "integrity": "sha512-0j/ZfZMxKukDaag2PtOPDbwuELqIar6lLskVPPJDjXMXjfLb1Obo/1yjxIGqqAJrmfaTIY3z2wFLAQ7qSkLsuA==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.18.6",
@@ -4767,7 +4767,7 @@
         "@babel/helper-function-name": "^7.19.0",
         "@babel/helper-hoist-variables": "^7.18.6",
         "@babel/helper-split-export-declaration": "^7.18.6",
-        "@babel/parser": "^7.19.0",
+        "@babel/parser": "^7.19.1",
         "@babel/types": "^7.19.0",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
@@ -5149,9 +5149,9 @@
       }
     },
     "@sinclair/typebox": {
-      "version": "0.24.41",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.24.41.tgz",
-      "integrity": "sha512-TJCgQurls4FipFvHeC+gfAzb+GGstL0TDwYJKQVtTeSvJIznWzP7g3bAd5gEBlr8+bIxqnWS9VGVWREDhmE8jA==",
+      "version": "0.24.42",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.24.42.tgz",
+      "integrity": "sha512-d+2AtrHGyWek2u2ITF0lHRIv6Tt7X0dEHW+0rP+5aDCEjC3fiN2RBjrLD0yU0at52BcZbRGxLbAtXiR0hFCjYw==",
       "dev": true
     },
     "@sinonjs/commons": {
@@ -5310,9 +5310,9 @@
       "optional": true
     },
     "@swc/core-linux-x64-gnu": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.3.0.tgz",
-      "integrity": "sha512-Ds76Lu7vfE01rgFcf9O1OuNBwQSHBpGwGOKGnwob6T2SCR4DBQz4MD0jLw/tdCZGR8x7NVMteBzQAp3CsUORZw==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.3.1.tgz",
+      "integrity": "sha512-gNojY1qIKksK9kNdY4pqrlUILTxfqSWtXjX0qV2mlxgwRpnOATJnMx585q09cOZnkN2/QB+33pXnT8z/wxuGzQ==",
       "optional": true
     },
     "@swc/core-linux-x64-musl": {
@@ -5687,15 +5687,15 @@
       }
     },
     "browserslist": {
-      "version": "4.21.3",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.3.tgz",
-      "integrity": "sha512-898rgRXLAyRkM1GryrrBHGkqA5hlpkV5MhtZwg9QXeiyLUYs2k00Un05aX5l2/yJIOObYKOpS2JNo8nJDE7fWQ==",
+      "version": "4.21.4",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.4.tgz",
+      "integrity": "sha512-CBHJJdDmgjl3daYjN5Cp5kbTf1mUhZoS+beLklHIvkOWscs83YAhLlF3Wsh/lciQYAcbBJgTOD44VtG31ZM4Hw==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "^1.0.30001370",
-        "electron-to-chromium": "^1.4.202",
+        "caniuse-lite": "^1.0.30001400",
+        "electron-to-chromium": "^1.4.251",
         "node-releases": "^2.0.6",
-        "update-browserslist-db": "^1.0.5"
+        "update-browserslist-db": "^1.0.9"
       }
     },
     "bs-logger": {
@@ -5735,9 +5735,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001399",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001399.tgz",
-      "integrity": "sha512-4vQ90tMKS+FkvuVWS5/QY1+d805ODxZiKFzsU8o/RsVJz49ZSRR8EjykLJbqhzdPgadbX6wB538wOzle3JniRA==",
+      "version": "1.0.30001402",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001402.tgz",
+      "integrity": "sha512-Mx4MlhXO5NwuvXGgVb+hg65HZ+bhUYsz8QtDGDo2QmaJS2GBX47Xfi2koL86lc8K+l+htXeTEB/Aeqvezoo6Ew==",
       "dev": true
     },
     "chalk": {
@@ -5900,9 +5900,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.4.248",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.248.tgz",
-      "integrity": "sha512-qShjzEYpa57NnhbW2K+g+Fl+eNoDvQ7I+2MRwWnU6Z6F0HhXekzsECCLv+y2OJUsRodjqoSfwHkIX42VUFtUzg==",
+      "version": "1.4.254",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.254.tgz",
+      "integrity": "sha512-Sh/7YsHqQYkA6ZHuHMy24e6TE4eX6KZVsZb9E/DvU1nQRIrH4BflO/4k+83tfdYvDl+MObvlqHPRICzEdC9c6Q==",
       "dev": true
     },
     "emittery": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "lib",
   "types": "src",
   "scripts": {
-    "bench": "node --experimental-fetch ./tools/bench.js",
+    "bench": "node --experimental-fetch --cpu-prof --cpu-prof-dir './cpu-profiles/' ./tools/bench.js",
     "build": "npx rimraf ./lib && swc src --out-dir lib",
     "prepublish": "npm run build",
     "test": "jest",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,19 +1,17 @@
 export {
   normalizeHost,
   resolveHostFromRequest,
-  resolveIpFromRequest,
-  isLocalAddress
+  resolveIpFromRequest
 } from './util';
 export {
   Metrics,
   MetricsOptions,
   ActorStatus,
   BadActorType,
-  PURGE_DELAY,
   DEFAULT_HISTORY_SIZE,
   DEFAULT_MAX_AGE,
-  DEFAULT_MIN_HOST_REQUESTS,
-  DEFAULT_MIN_IP_REQUESTS,
+  DEFAULT_MIN_HOST_RATE, DEFAULT_MAX_HOST_RATE,
+  DEFAULT_MIN_IP_RATE, DEFAULT_MAX_IP_RATE,
   DEFAULT_HOST_WHITELIST,
   DEFAULT_IP_WHITELIST
 } from './metrics';

--- a/src/util.ts
+++ b/src/util.ts
@@ -24,25 +24,3 @@ export function resolveIpFromRequest(req: IncomingMessage|Http2ServerRequest, be
     'unknown'
   ;
 }
-
-// subset of https://github.com/tinovyatkin/is-localhost-ip/blob/master/index.js#L13
-const IP_RANGES = [
-  // 127.0.0.0 - 127.255.255.255
-  /^(:{2}f{4}:)?127(?:\.\d{1,3}){3}$/,
-  // 192.168.0.0 - 192.168.255.255
-  /^(:{2}f{4}:)?192\.168(?:\.\d{1,3}){2}$/,
-  // 172.16.0.0 - 172.31.255.255
-  /^(:{2}f{4}:)?(172\.1[6-9]|172\.2\d|172\.3[01])(?:\.\d{1,3}){2}$/,
-  // fc00::/7
-  /^f[cd][\da-f]{2}(::1$|:[\da-f]{1,4}){1,7}$/,
-  // fe80::/10
-  /^fe[89ab][\da-f](::1$|:[\da-f]{1,4}){1,7}$/,
-];
-
-const IP_TESTER = new RegExp(
-  `^(${IP_RANGES.map((re) => re.source).join('|')})$`,
-);
-
-export function isLocalAddress(ip: string): boolean {
-  return IP_TESTER.test(ip);
-}

--- a/test/metrics.test.ts
+++ b/test/metrics.test.ts
@@ -1,6 +1,9 @@
-import { IncomingMessage } from 'http';
-import { Http2ServerRequest } from 'http2';
-import { Metrics, DEFAULT_HOST_WHITELIST, DEFAULT_IP_WHITELIST, PURGE_DELAY } from '../src';
+import {
+  Metrics,
+  DEFAULT_HOST_WHITELIST, DEFAULT_IP_WHITELIST,
+  DEFAULT_MIN_HOST_RATE,DEFAULT_MAX_HOST_RATE,
+  DEFAULT_MIN_IP_RATE,DEFAULT_MAX_IP_RATE
+} from '../src';
 import { ActorStatus } from '../src/metrics';
 
 global.Date.now = jest.fn();
@@ -12,12 +15,12 @@ beforeEach(() => {
 describe('constructor', () => {
   it('defaults', () => {
     const metrics = new Metrics();
-    expect(metrics.historySize).toEqual(300);
+    expect(metrics.historySize).toEqual(200);
     expect(metrics.maxAge).toEqual(1000 * 10);
-    expect(metrics.minHostRequests).toEqual(30);
-    expect(metrics.minIpRequests).toEqual(100);
-    expect(metrics.maxHostRate).toEqual(0);
-    expect(metrics.maxIpRate).toEqual(0);
+    expect(metrics.minHostRate).toEqual(DEFAULT_MIN_HOST_RATE);
+    expect(metrics.maxHostRate).toEqual(DEFAULT_MAX_HOST_RATE);
+    expect(metrics.minIpRate).toEqual(DEFAULT_MIN_IP_RATE);
+    expect(metrics.maxIpRate).toEqual(DEFAULT_MAX_IP_RATE);
     expect(Array.from(metrics.hostWhitelist)).toEqual(DEFAULT_HOST_WHITELIST);
     expect(Array.from(metrics.ipWhitelist)).toEqual(DEFAULT_IP_WHITELIST);
   });
@@ -26,209 +29,124 @@ describe('constructor', () => {
     const metrics = new Metrics({
       historySize: 400,
       maxAge: 1000 * 60 * 5,
-      minHostRequests: 150,
-      minIpRequests: 200,
-      maxHostRate: 1,
-      maxIpRate: 2,
+      minHostRate: 150,
+      maxHostRate: 200,
+      minIpRate: 50,
+      maxIpRate: 100,
       hostWhitelist: new Set(['h1', 'h2']),
       ipWhitelist: new Set(['i1', 'i2'])
     });
     expect(metrics.historySize).toEqual(400);
     expect(metrics.maxAge).toEqual(1000 * 60 * 5);
-    expect(metrics.minHostRequests).toEqual(150);
-    expect(metrics.minIpRequests).toEqual(200);
-    expect(metrics.maxHostRate).toEqual(1);
-    expect(metrics.maxIpRate).toEqual(2);
+    expect(metrics.minHostRate).toEqual(150);
+    expect(metrics.maxHostRate).toEqual(200);
+    expect(metrics.minIpRate).toEqual(50);
+    expect(metrics.maxIpRate).toEqual(100);
     expect(Array.from(metrics.hostWhitelist)).toEqual(['h1', 'h2']);
     expect(Array.from(metrics.ipWhitelist)).toEqual(['i1', 'i2']);
   });
 
-  it('throws if minHostRequests exceeds historySize', () => {
-    expect(() => new Metrics({ minHostRequests: 1000 })).toThrow();
+  it('throws if minHostRate exceeds maxHostRate', () => {
+    expect(() => new Metrics({ minHostRate: 2, maxHostRate: 1 })).toThrow();
   });
 
-  it('throws if minIpRequests exceeds historySize', () => {
-    expect(() => new Metrics({ minIpRequests: 1000 })).toThrow();
-  });
-});
-
-describe('trackRequest', () => {
-  it('http.headers.host is valid', () => {
-    const metrics = new Metrics();
-    metrics.trackRequest({
-      headers: { 'host': 'a' }
-    } as IncomingMessage);
-    expect(metrics.hosts.get('a')).toEqual({ id: 'a', history: [0], hits: 1, rate: 0, ratio: 0 });
-    expect(metrics.ips.get('unknown')).toEqual({ id: 'unknown', history: [0], hits: 1, rate: 0, ratio: 0 });
-  });
-
-  it('http2.headers.:authority is valid', () => {
-    const metrics = new Metrics();
-    metrics.trackRequest({
-      headers: { ':authority': 'b' }
-    } as Http2ServerRequest);
-    expect(metrics.hosts.get('b')).toEqual({ id: 'b', history: [0], hits: 1, rate: 0, ratio: 0 });
-    expect(metrics.ips.get('unknown')).toEqual({ id: 'unknown', history: [0], hits: 1, rate: 0, ratio: 0 });
-  });
-
-  it('http.headers.x-forwarded-for is valid', () => {
-    const metrics = new Metrics();
-    /* @ts-ignore */
-    metrics.trackRequest({
-      headers: { },
-      socket: { remoteAddress: 'c' }
-    } as IncomingMessage);
-    expect(metrics.hosts.get('unknown')).toEqual({ id: 'unknown', history: [0], hits: 1, rate: 0, ratio: 0 });
-    expect(metrics.ips.get('c')).toEqual({ id: 'c', history: [0], hits: 1, rate: 0, ratio: 0 });
-  });
-
-  it('socket.remoteAddress is valid', () => {
-    const metrics = new Metrics();
-    /* @ts-ignore */
-    metrics.trackRequest({
-      headers: {},
-      socket: { remoteAddress: 'd' }
-    } as IncomingMessage);
-    expect(metrics.hosts.get('unknown')).toEqual({ id: 'unknown', history: [0], hits: 1, rate: 0, ratio: 0 });
-    expect(metrics.ips.get('d')).toEqual({ id: 'd', history: [0], hits: 1, rate: 0, ratio: 0 });
+  it('throws if minIpRate exceeds maxIpRate', () => {
+    expect(() => new Metrics({ minIpRate: 2, maxIpRate: 1 })).toThrow();
   });
 });
 
-describe('LRU', () => {
-  it('invokes dispose to reset hostRequests', () => {
-    const metrics = new Metrics();
-    /* @ts-ignore */
-    metrics.trackRequest({
-      headers: { host: 'a' }
-    } as IncomingMessage);
-    expect(metrics.hostRequests).toEqual(1);
-    metrics.hosts.clear();
-    expect(metrics.hostRequests).toEqual(0);
+describe('props', () => {
+  it('do NOT cache host if rate limiting disabled', () => {
+    const metrics = new Metrics({ minHostRate: 0 });
+    expect(metrics.hosts.get('a')).toEqual(undefined);
+    metrics.trackHost('a');
+    expect(metrics.hosts.get('a')).toEqual(undefined);
   });
 
-  it('invokes dispose to reset ipRequests', () => {
-    const metrics = new Metrics();
-    /* @ts-ignore */
-    metrics.trackRequest({
-      headers: {},
-      socket: { remoteAddress: 'a' }
-    } as IncomingMessage);
-    expect(metrics.ipRequests).toEqual(1);
-    metrics.ips.clear();
-    expect(metrics.ipRequests).toEqual(0);
+  it('cache host if rate limiting', () => {
+    const metrics = new Metrics({ minHostRate: 1, maxHostRate: 1 });
+    expect(metrics.hosts.get('a')).toEqual(undefined);
+    metrics.trackHost('a');
+    expect(typeof metrics.hosts.get('a')).toEqual('object');
+  });
+
+  it('do NOT cache IP if rate limiting disabled', () => {
+    const metrics = new Metrics({ minIpRate: 0 });
+    expect(metrics.ips.get('a')).toEqual(undefined);
+    metrics.trackIp('a');
+    expect(metrics.ips.get('a')).toEqual(undefined);
+  });
+
+  it('cache IP if rate limiting', () => {
+    const metrics = new Metrics({ minIpRate: 1, maxIpRate: 1 });
+    expect(metrics.ips.get('a')).toEqual(undefined);
+    metrics.trackIp('a');
+    expect(typeof metrics.ips.get('a')).toEqual('object');
   });
 });
 
 describe('getHostInfo', () => {
-  it('returns Good if min set to false', () => {
-    const metrics = new Metrics({ minHostRequests: false });
-    /* @ts-ignore */
-    const req = {
-      headers: { ':authority': 'a' }
-    } as IncomingMessage;
-    expect(metrics.getHostInfo(req, false)).toEqual(ActorStatus.Good);
-    expect(metrics.getHostInfo(req, true)).toEqual(ActorStatus.Good);
+  it('returns Good if rate limiting disabled', () => {
+    const metrics = new Metrics({ minHostRate: 0 });
+    metrics.trackHost('a');
+    metrics.trackHost('a');
+    metrics.trackHost('a');
+    expect(metrics.getHostInfo('a')).toEqual(ActorStatus.Good);
   });
 
   it('returns whitelisted if in list', () => {
-    const metrics = new Metrics({ hostWhitelist: new Set(['a']) });
-    /* @ts-ignore */
-    const req = {
-      headers: { ':authority': 'a' }
-    } as IncomingMessage;
-    metrics.trackHost(req);
-    expect(metrics.getHostInfo(req)).toEqual(ActorStatus.Whitelisted);
-    req.headers[':authority'] = 'b';
-    metrics.trackHost(req);
-    expect(metrics.getHostInfo(req)?.ratio).toEqual(0);
+    const metrics = new Metrics({ hostWhitelist: new Set(['a']), minHostRate: 1, maxHostRate: 1 });
+    metrics.trackHost('a'); // would not normally be tracked if whitelisted, but no affect
+    expect(metrics.getHostInfo('a')).toEqual(ActorStatus.Whitelisted); // no history required
+    metrics.trackHost('b');
+    expect(typeof metrics.getHostInfo('b')).toEqual('object');
   });
 
-  it(':authority respected', () => {
-    const metrics = new Metrics({ minHostRequests: 2 });
-    /* @ts-ignore */
-    const req = {
-      headers: { ':authority': 'a' }
-    } as IncomingMessage;
-    metrics.trackHost(req);
-    expect(metrics.getHostInfo(req)?.ratio).toEqual(0); // insufficient history
-    metrics.trackHost(req);
-    expect(metrics.getHostInfo(req)?.ratio).toEqual(1); // sufficient history
-    expect(metrics.getHostInfo('a')?.ratio).toEqual(1); // by name also matches
-  });
-
-  it('purge after PURGE_DELAY', () => {
-    const metrics = new Metrics({ maxAge: 1000, minHostRequests: 1 });
-    metrics.trackHost({
-      headers: { host: 'a' }
-    } as IncomingMessage);
-    expect(metrics.hostRequests).toEqual(1);
-    expect(metrics.getHostInfo('a')?.ratio).toEqual(1);
-    global.Date.now.mockReturnValue(PURGE_DELAY);
-    metrics.trackHost({
-      headers: { host: 'b' }
-    } as IncomingMessage);
-    expect(metrics.hostRequests).toEqual(1); // host 'a' should have been purged
-    expect(metrics.hosts.get('a')).toEqual(undefined);
-    expect(metrics.getHostInfo('a')).toEqual(undefined); // they all expired
-    expect(metrics.getHostInfo('b')?.ratio).toEqual(1);
+  it('purge anything stale prior to getInfo', () => {
+    const maxAge = 1000;
+    const minHostRate = 10;
+    const metrics = new Metrics({ maxAge, minHostRate, maxHostRate: minHostRate });
+    let i;
+    for (i = 0; i < minHostRate; i++) {
+      metrics.trackHost('a');
+    }
+    expect(metrics.getHostInfo('a')?.history.length).toEqual(minHostRate); // nothing dropped
+    expect(metrics.getHostInfo('a')?.rate).toEqual(10000); // no time has passed, so 1ms minimum assumed = 10K RPS
+    global.Date.now.mockReturnValue(maxAge+1);
+    expect(metrics.getHostInfo('a')?.history.length).toEqual(0); // everything is stale
+    expect(metrics.getHostInfo('a')?.rate).toEqual(0); // insufficient history
   });
 });
 
 describe('getIpInfo', () => {
-  it('returns Good if min set to false', () => {
-    const metrics = new Metrics({ minIpRequests: false });
-    /* @ts-ignore */
-    const req = {
-      headers: { },
-      socket: { remoteAddress: 'a' }
-    } as IncomingMessage;
-    expect(metrics.getIpInfo(req, false)).toEqual(ActorStatus.Good);
-    expect(metrics.getIpInfo(req, true)).toEqual(ActorStatus.Good);
+  it('returns Good if rate limiting disabled', () => {
+    const metrics = new Metrics({ minIpRate: 0 });
+    metrics.trackIp('a');
+    metrics.trackIp('a');
+    metrics.trackIp('a');
+    expect(metrics.getIpInfo('a')).toEqual(ActorStatus.Good);
   });
 
   it('returns whitelisted if in list', () => {
-    const metrics = new Metrics({ ipWhitelist: new Set(['a']) });
-    /* @ts-ignore */
-    const req = {
-      headers: { },
-      socket: { remoteAddress: 'a' }
-    } as IncomingMessage;
-    metrics.trackIp(req);
-    expect(metrics.getIpInfo(req)).toEqual(ActorStatus.Whitelisted);
-    req.socket.remoteAddress = 'b';
-    metrics.trackIp(req);
-    expect(metrics.getIpInfo(req)?.ratio).toEqual(0);
+    const metrics = new Metrics({ ipWhitelist: new Set(['a']), minIpRate: 1, maxIpRate: 1 });
+    metrics.trackIp('a'); // would not normally be tracked if whitelisted, but no affect
+    expect(metrics.getIpInfo('a')).toEqual(ActorStatus.Whitelisted); // no history required
+    metrics.trackIp('b');
+    expect(typeof metrics.getIpInfo('b')).toEqual('object');
   });
 
-  it('x-forwarded-for respected', () => {
-    const metrics = new Metrics({ minIpRequests: 2, behindProxy: true });
-    /* @ts-ignore */
-    const req = {
-      headers: { 'x-forwarded-for': 'a' }
-    } as IncomingMessage;
-    metrics.trackIp(req);
-    expect(metrics.getIpInfo(req)?.ratio).toEqual(0); // insufficient history
-    metrics.trackIp(req);
-    expect(metrics.getIpInfo(req)?.ratio).toEqual(1); // sufficient history
-    expect(metrics.getIpInfo('a')?.ratio).toEqual(1); // by name also matches
-  });
-
-  it('purge after PURGE_DELAY', () => {
-    const metrics = new Metrics({ maxAge: 1000, minIpRequests: 1 });
-    metrics.trackIp({
-      headers: { },
-      socket: { remoteAddress: 'a' }
-    } as IncomingMessage);
-    expect(metrics.ipRequests).toEqual(1);
-    expect(metrics.getIpInfo('a')?.ratio).toEqual(1);
-    global.Date.now.mockReturnValue(PURGE_DELAY);
-    metrics.trackIp({
-      headers: { },
-      socket: { remoteAddress: 'b' }
-    } as IncomingMessage);
-    expect(metrics.ipRequests).toEqual(1); // ip 'a' should have been purged
-    expect(metrics.ips.get('a')).toEqual(undefined);
-    expect(metrics.getIpInfo('a')).toEqual(undefined); // they all expired
-    expect(metrics.getIpInfo('b')?.ratio).toEqual(1);
+  it('purge anything stale prior to getInfo', () => {
+    const maxAge = 1000;
+    const minIpRate = 10;
+    const metrics = new Metrics({ maxAge, minIpRate, maxIpRate: minIpRate });
+    let i;
+    for (i = 0; i < minIpRate; i++) {
+      metrics.trackIp('a');
+    }
+    expect(metrics.getIpInfo('a')?.history.length).toEqual(minIpRate); // nothing dropped
+    expect(metrics.getIpInfo('a')?.rate).toEqual(10000); // no time has passed, so 1ms minimum assumed = 10K RPS
+    global.Date.now.mockReturnValue(maxAge+1);
+    expect(metrics.getIpInfo('a')?.history.length).toEqual(0); // everything is stale
+    expect(metrics.getIpInfo('a')?.rate).toEqual(0); // insufficient history
   });
 });


### PR DESCRIPTION
## 5.0.0

This release is about simplifying options, improved performance, and
predictable results (less "magic").

- **Breaking** `maxHostRate` option work the similar as before,
  but now require `minHostRate` to be set as well so that rate
  limiting is based on the lag ratio between `minLag` and `maxLag`.
  Additionally host rate limiting is enabled by default
- **Breaking** `maxIpRate` option work the similar as before,
  but now require `minIpRate` to be set as well so that rate
  limiting is based on the lag ratio between `minLag` and `maxLag`.
  IP rate limiting remains disabled by default
- **Breaking** `behindProxy` has been replaced with `httpBehindProxy`
  and `httpsBehindProxy` to account for possible differences between
  bindings
- **Breaking** `exemptLocalAddress` has been removed in favor
  of existing whitelisting. This "feature" was highly flawed and
  could potentially flag any internal NAT addresses as exempt when
  the intention is really only to exempt the immediate host
- **Breaking** All `Threshold` options have been removed blocking
  has shifted entirely to rate limiting via `minHostRate` and
  `minIpRate`. Additionally minimum request options have been
  removed, but rate limiting now must meet `minHostRate` or
  `minIpRate`