### PR TITLE
Fix exception due to null regex match

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -4,7 +4,8 @@ import { Http2ServerRequest } from 'http2';
 const HOST_NORMALIZE_REGEX = /(^www\.)?([^:]+)(:\d+)?$/;
 
 export function normalizeHost(host: string): string {
-  return HOST_NORMALIZE_REGEX.exec(host.toLowerCase())[2];
+  const match = HOST_NORMALIZE_REGEX.exec(host.toLowerCase());
+  return match ? match[2] : host;
 }
 
 export function resolveHostFromRequest(req: IncomingMessage|Http2ServerRequest): string {


### PR DESCRIPTION
Fixes a bug where invalid hostnames can result in uncaught exceptions.