### PR TITLE
Add ability to adjust max IP rate for host violations

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ otherwise you may face an attack and not know about it.
 
 Using Connect or Express?
 
-	const 
+	const
 		connect = require("connect"),
 		http = require("http");
 	const { ConnectQOS } = require("connect-qos");
@@ -89,6 +89,10 @@ For you tweakers out there, here's some levers to pull:
 * **minIpRate** (default: `0`) - Minimum rate if lag is >= maxLag. Disable
   rate limiting by setting to `0`.
 * **maxIpRate** (default: `0`) - Maximum rate if lag is <= minLag.
+* **maxIpRateHostViolation** (default: `0`) - Maximum rate if target host is currently exceeding the
+* configured `maxHostRatio`. This can be used to increase IP throttling if a particular host is being
+* targeted by a large number of IPs. Requests hitting this max rate will return `badIp` instead of
+* `hostViolation`.
 * **errorStatusCode** (default: `503`) - The HTTP status code to return if the
   request has been throttled.
 * **historySize** (default: `200`) - The LRU history size to use in

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -8,6 +8,7 @@ export type MetricsOptions = {
   maxHostRatio?: number;
   minIpRate?: number;
   maxIpRate?: number;
+  maxIpRateHostViolation?: number;
   hostWhitelist?: Set<string>;
   ipWhitelist?: Set<string>;
 }
@@ -38,6 +39,7 @@ export const DEFAULT_MAX_HOST_RATE: number = 40;
 export const DEFAULT_MAX_HOST_RATIO: number = 0; // disabled
 export const DEFAULT_MIN_IP_RATE: number = 0; // disabled
 export const DEFAULT_MAX_IP_RATE: number = 0; // disabled
+export const DEFAULT_MAX_IP_RATE_BUSY_HOST: number = 0; // disabled
 export const DEFAULT_HOST_WHITELIST = ['localhost'];
 export const DEFAULT_IP_WHITELIST = [];
 
@@ -51,6 +53,7 @@ export class Metrics {
       maxHostRatio = DEFAULT_MAX_HOST_RATIO,
       minIpRate = DEFAULT_MIN_IP_RATE,
       maxIpRate = DEFAULT_MAX_IP_RATE,
+      maxIpRateHostViolation = DEFAULT_MAX_IP_RATE_BUSY_HOST,
       hostWhitelist = new Set(DEFAULT_HOST_WHITELIST),
       ipWhitelist = new Set(DEFAULT_IP_WHITELIST)
     } = (opts || {} as MetricsOptions);
@@ -76,6 +79,7 @@ export class Metrics {
     this.#hostRatioMaxCount = Math.ceil(this.#maxHostRatio * 100 * 10); // 10x requests compared to host ratio (10% * 10 = 100)
     this.#minIpRate = minIpRate;
     this.#maxIpRate = maxIpRate;
+    this.#maxIpRateHostViolation = maxIpRateHostViolation;
     this.#minIpRequests = Math.round(minIpRate * (maxAge/1000));
     this.#hostWhitelist = hostWhitelist;
     this.#ipWhitelist = ipWhitelist;
@@ -95,6 +99,7 @@ export class Metrics {
   #hostRatioCounts = new Map<string, number>();
   #minIpRate: number;
   #maxIpRate: number;
+  #maxIpRateHostViolation: number;
   #minIpRequests: number;
   #hostWhitelist: Set<string>;
   #ipWhitelist: Set<string>;
@@ -129,6 +134,10 @@ export class Metrics {
 
   get maxIpRate(): number {
     return this.#maxIpRate;
+  }
+
+  get maxIpRateHostViolation(): number {
+    return this.#maxIpRateHostViolation;
   }
 
   get historySize(): number {
@@ -241,7 +250,7 @@ function getInfo(source: string, {
       const eldest = cache.history[0];
       // default to 1ms to avoid divide by zero errors since we do have adequate history
       const age = (now - eldest) || 1;
-  
+
       cache.rate = ((cache.history.length / age) * 1000);
     }
   }


### PR DESCRIPTION
This PR introduces a new config `maxIpRateHostViolation` which allows users to adjust the max IP rate for hosts whose requests have exceeded the `maxHostRatio` setting. This is useful if clients don't want to block all traffic to hosts during these periods of abuse, but instead simply want to more aggressively throttle IPs that are targeting the hosts under attack. 