### PR TITLE
Add support for errorResponseDelay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+## 5.5.0
+
+- **Feature** Add support for `errorResponseDelay` option
+
+## 5.4.0
+
+- **Feature** Add support for closing http/2 connections
+
+## 5.3.0
+
+- **Feature** Add support for adjusting IP throttle rate based on host ratio
+
+## 5.2.0
+
+- **Feature** Add support for throttling based on host ratio
+
 ## 5.1.0
 
 - **Breaking** Options remain identical but rate limiting is now

--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ For you tweakers out there, here's some levers to pull:
 	requests below the rate threshold but hitting the target host will not be flagged.
 * **errorStatusCode** (default: `503`) - The HTTP status code to return if the
   request has been throttled.
+*	**errorResponseDelay** (default: `0`) - Number of milliseconds to delay sending an error response to
+	bad actors. A value of 0 will result in the response being sent synchronously before returning from the middleware.
 * **historySize** (default: `200`) - The LRU history size to use in
   tracking bad actors. Hosts and IPs both get their own dedicated LRU.
 * **maxAge** (default: `10000`) - Time (in ms) before history is purged.

--- a/README.md
+++ b/README.md
@@ -95,8 +95,8 @@ For you tweakers out there, here's some levers to pull:
 	requests below the rate threshold but hitting the target host will not be flagged.
 * **errorStatusCode** (default: `503`) - The HTTP status code to return if the
   request has been throttled.
-*	**errorResponseDelay** (default: `0`) - Number of milliseconds to delay sending an error response to
-	bad actors. A value of 0 will result in the response being sent synchronously before returning from the middleware.
+* **errorResponseDelay** (default: `0`) - Number of milliseconds to delay sending an error response to
+  bad actors. A value of 0 will result in the response being sent synchronously before returning from the middleware.
 * **historySize** (default: `200`) - The LRU history size to use in
   tracking bad actors. Hosts and IPs both get their own dedicated LRU.
 * **maxAge** (default: `10000`) - Time (in ms) before history is purged.


### PR DESCRIPTION
Also fixes an issue where we weren't honoring the `destroySocket` middleware option