### PR TITLE
Use session.destroy for http2 connections

### DIFF
--- a/src/connect.ts
+++ b/src/connect.ts
@@ -88,8 +88,12 @@ export class ConnectQOS {
     function sendError(res: Http2ServerResponse | ServerResponse) {
       res.statusCode = self.#errorStatusCode;
       res.end();
-      if (destroySocket && res.socket?.destroyed === false) {
-        res.socket.destroySoon();
+      if (destroySocket) {
+        if (res.stream) { // H2
+          res.stream.session?.destroy();
+        } else if (res.socket?.destroyed === false) {
+          res.socket.destroySoon();
+        }
       }
     }
 


### PR DESCRIPTION
Destroying the underlying socket may be causing downstream issues for HTTP/2 sessions. This PR changes our approach to detect HTTP/2 requests and call [destroy](https://nodejs.org/api/http2.html#http2sessiondestroyerror-code) on the `HTTP2Session` instance instead of on the underlying socket.