### PR TITLE
Honor host whitelist for ratio and limit history window time

### DIFF
--- a/test/metrics.test.ts
+++ b/test/metrics.test.ts
@@ -214,4 +214,12 @@ describe('maxHostRatio', () => {
     Array.from({ length: Math.round(requiredHits * 0.6) }, () => metrics.trackHost('b')); // 60% to 'b'
     expect([...metrics.hostRatioViolations.values()]).toEqual(['b']);
   });
+
+  it('will not report if host is whitelisted', () => {
+    const metrics = new Metrics({ maxHostRatio: 0.5, hostWhitelist: new Set(['b']) });
+    const requiredHits = Math.ceil(metrics.maxHostRatio * 100 * 10); // 10x host ratio required before reporting violations
+    Array.from({ length: Math.round(requiredHits * 0.4) }, () => metrics.trackHost('a')); // 40% to 'a'
+    Array.from({ length: Math.round(requiredHits * 0.6) }, () => metrics.trackHost('b')); // 60% to 'b'
+    expect([...metrics.hostRatioViolations.values()]).toEqual([]);
+  });
 });


### PR DESCRIPTION
This PR includes 2 changes/fixes to our max host ratio functionality:

1. Makes sure that we honor the host whitelist, so even if requests to that host exceed the configured max host ratio we will not throttle those requests
2. Only considers the last 60 seconds of request history when calculating the ratio - as typically consumers would not care if a large percentage of traffic is going to a particular host if the overall traffic rate is very low.