### PR TITLE
fix: security and correctness hardening from comprehensive library review

### DIFF
--- a/src/connect.ts
+++ b/src/connect.ts
@@ -37,6 +37,7 @@ export class ConnectQOS {
     } = (opts || {} as ConnectQOSOptions);
 
     if (subnetMaskBits < 20 || subnetMaskBits > 30) throw new Error(`subnetMaskBits ${subnetMaskBits} must be between 20 and 30`);
+    if (minLag >= maxLag) throw new Error(`${minLag} minLag must be less than ${maxLag} maxLag`);
 
     this.#minLag = minLag;
     this.#maxLag = maxLag;
@@ -112,7 +113,7 @@ export class ConnectQOS {
       if (reason) {
         if (!beforeThrottle || beforeThrottle(self, req, reason as string) !== false) {
           // if no throttle handler OR the throttle handler does not explicitly reject, do it
-          return void self.#errorResponseDelay ? setTimeout(sendError, self.#errorResponseDelay, res).unref() : sendError(res);
+          return void (self.#errorResponseDelay ? setTimeout(sendError, self.#errorResponseDelay, res).unref() : sendError(res));
         }
       }
 
@@ -193,12 +194,13 @@ export class ConnectQOS {
     const sourceStr: string = this.resolveHost(source);
     const sourceInfo = this.#metrics.getHostInfo(sourceStr);
 
+    if (sourceInfo === ActorStatus.Whitelisted) return ActorStatus.Whitelisted;
+
     const status = getStatus(sourceInfo, {
       minRate: this.#metrics.minHostRate,
       rateRange: this.#hostRateRange,
       lagRatio: this.lagRatio
     });
-    if (sourceInfo === ActorStatus.Whitelisted) return ActorStatus.Whitelisted;
 
     if (track && status === ActorStatus.Good) {
       // only track if we're NOT throttling
@@ -214,9 +216,12 @@ export class ConnectQOS {
   }
 
   resolveIp(source: string|IncomingMessage|Http2ServerRequest): string {
-    return typeof source === 'string' ? source
-      : resolveIpFromRequest(source, (source as Http2ServerRequest).scheme === 'https' ? this.#httpsBehindProxy : this.#httpBehindProxy)
-    ;
+    if (typeof source === 'string') return source;
+    // HTTP/2: use :scheme pseudo-header. HTTP/1.1: fall back to socket.encrypted (set by Node's TLS stack).
+    // Without the socket.encrypted check, HTTP/1.1 HTTPS connections fall through to httpBehindProxy,
+    // causing QOS to trust x-forwarded-for for direct TLS connections (IP spoofing risk).
+    const isHttps = (source as Http2ServerRequest).scheme === 'https' || (source.socket as any)?.encrypted === true;
+    return resolveIpFromRequest(source, isHttps ? this.#httpsBehindProxy : this.#httpBehindProxy);
   }
 
   getIpStatus(source: string|IncomingMessage|Http2ServerRequest, track: boolean = true, rateRange: number = this.#ipRateRange, minRate: number = this.#metrics.minIpRate): ActorStatus {

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -212,14 +212,16 @@ export class Metrics {
   }
 
   trackHost(source: string, cache?: CacheItem): CacheItem|undefined {
+    if (this.#hostWhitelist.has(source)) return;
     if (this.#maxHostRatio) {
-      // only track if ratio limits enabled
-      if (!this.#hostWhitelist.has(source)) {
-        this.#hostRatioCounts.set(source, (this.#hostRatioCounts.get(source) || 0) + 1);
-      }
-      this.#hostRatioRequestHistory = this.#hostRatioRequestHistory
-        .concat(Date.now())
-        .filter((ts) => ts >= Date.now() - 60000); // 1 minute history
+      // only track if ratio limits enabled (source is never whitelisted here — guarded above)
+      this.#hostRatioCounts.set(source, (this.#hostRatioCounts.get(source) || 0) + 1);
+      const now = Date.now();
+      this.#hostRatioRequestHistory.push(now);
+      const cutoff = now - 60000; // 1 minute history
+      let staleCount = 0;
+      while (staleCount < this.#hostRatioRequestHistory.length && this.#hostRatioRequestHistory[staleCount] < cutoff) staleCount++;
+      if (staleCount) this.#hostRatioRequestHistory.splice(0, staleCount);
 
       if (this.#hostRatioRequestHistory.length >= this.#hostRatioMaxCount) {
         // check for violations once we have sufficient history
@@ -251,6 +253,7 @@ export class Metrics {
   }
 
   trackIp(source: string, cache?: CacheItem): CacheItem|undefined {
+    if (this.#ipWhitelist.has(source)) return;
     return track(source, {
       lru: this.#ips,
       cache,

--- a/src/util.ts
+++ b/src/util.ts
@@ -19,8 +19,9 @@ export function resolveHostFromRequest(req: IncomingMessage|Http2ServerRequest):
 export function resolveIpFromRequest(req: IncomingMessage|Http2ServerRequest, behindProxy = false): string {
   // for security reasons, we should never ASSUME the server is behind a proxy
   // and only support `x-forwarded-for` is explicitly enabled
-  const xffHeader = behindProxy && req.headers['x-forwarded-for'] as string|undefined;
-  const forwardedFor: string = xffHeader && xffHeader.split(',')[0].trim();
+  const xffHeader = behindProxy ? req.headers['x-forwarded-for'] : undefined;
+  const xffValue = Array.isArray(xffHeader) ? xffHeader[0] : xffHeader;
+  const forwardedFor = typeof xffValue === 'string' ? xffValue.split(',')[0].trim() : undefined;
   return forwardedFor ||
     req?.socket?.remoteAddress ||
     'unknown'

--- a/src/util.ts
+++ b/src/util.ts
@@ -19,7 +19,8 @@ export function resolveHostFromRequest(req: IncomingMessage|Http2ServerRequest):
 export function resolveIpFromRequest(req: IncomingMessage|Http2ServerRequest, behindProxy = false): string {
   // for security reasons, we should never ASSUME the server is behind a proxy
   // and only support `x-forwarded-for` is explicitly enabled
-  const forwardedFor: string = behindProxy && req.headers['x-forwarded-for'] as string|undefined;
+  const xffHeader = behindProxy && req.headers['x-forwarded-for'] as string|undefined;
+  const forwardedFor: string = xffHeader && xffHeader.split(',')[0].trim();
   return forwardedFor ||
     req?.socket?.remoteAddress ||
     'unknown'

--- a/test/connect.test.ts
+++ b/test/connect.test.ts
@@ -43,6 +43,11 @@ describe('constructor', () => {
     expect(() => new ConnectQOS({ subnetMaskBits: 31 as any })).toThrow();
   });
 
+  it('throws if minLag >= maxLag', () => {
+    expect(() => new ConnectQOS({ minLag: 100, maxLag: 100 })).toThrow();
+    expect(() => new ConnectQOS({ minLag: 200, maxLag: 100 })).toThrow();
+  });
+
   it('subnetMaskBits defaults to 24', () => {
     // DEFAULT_SUBNET_MASK_BITS is 24; verify resolveSubnet uses /24 aggregation
     const qos = new ConnectQOS();
@@ -230,6 +235,18 @@ describe('getMiddleware', () => {
     expect(beforeThrottle).toHaveBeenCalledWith(qos, req, BadActorType.badHost);
     expect(writeHead).not.toHaveBeenCalled();
     expect(end).toHaveBeenCalled();
+  });
+
+  it('errorResponseDelay defers sendError via setTimeout', () => {
+    jest.useFakeTimers();
+    const qos = new ConnectQOS({ maxAge: 1000, minHostRate: 1, maxHostRate: 1, errorResponseDelay: 200 });
+    qos.isBadHost('unknown', true);
+    const end = jest.fn();
+    qos.getMiddleware()({ headers: {} } as IncomingMessage, { end, socket: { destroyed: true } }, () => {});
+    expect(end).not.toHaveBeenCalled(); // not called yet — waiting for delay
+    jest.advanceTimersByTime(200);
+    expect(end).toHaveBeenCalledTimes(1);
+    jest.useRealTimers();
   });
 
   it('beforeThrottle invoked if badHost bad not blocked if returns false', () => {
@@ -595,5 +612,32 @@ describe('resolveIp', () => {
       headers: { 'x-forwarded-for': 'a' },
       socket: { remoteAddress: 'ignored' }
     } as IncomingMessage)).toEqual('a');
+  });
+
+  it('extracts only the first IP from a comma-separated x-forwarded-for', () => {
+    const qos = new ConnectQOS({ httpBehindProxy: true });
+    expect(qos.resolveIp({
+      headers: { 'x-forwarded-for': '1.2.3.4, 10.0.0.1, 10.0.0.2' },
+      socket: { remoteAddress: 'ignored' }
+    } as IncomingMessage)).toEqual('1.2.3.4');
+  });
+
+  it('uses socket.remoteAddress for HTTP/1.1 TLS even if httpBehindProxy is true', () => {
+    // httpBehindProxy applies to plain HTTP. For TLS (socket.encrypted=true), httpsBehindProxy
+    // must be used instead — otherwise an attacker on an HTTPS connection could spoof their IP
+    // via x-forwarded-for even though no trusted proxy set that header.
+    const qos = new ConnectQOS({ httpBehindProxy: true, httpsBehindProxy: false });
+    expect(qos.resolveIp({
+      headers: { 'x-forwarded-for': 'spoofed' },
+      socket: { remoteAddress: '1.2.3.4', encrypted: true }
+    } as IncomingMessage)).toEqual('1.2.3.4');
+  });
+
+  it('trusts x-forwarded-for for HTTP/1.1 TLS when httpsBehindProxy is true', () => {
+    const qos = new ConnectQOS({ httpsBehindProxy: true });
+    expect(qos.resolveIp({
+      headers: { 'x-forwarded-for': '5.6.7.8' },
+      socket: { remoteAddress: 'ignored', encrypted: true }
+    } as IncomingMessage)).toEqual('5.6.7.8');
   });
 });

--- a/test/metrics.test.ts
+++ b/test/metrics.test.ts
@@ -115,7 +115,8 @@ describe('getHostInfo', () => {
 
   it('returns whitelisted if in list', () => {
     const metrics = new Metrics({ hostWhitelist: new Set(['a']), minHostRate: 1, maxHostRate: 1 });
-    metrics.trackHost('a'); // would not normally be tracked if whitelisted, but no affect
+    metrics.trackHost('a'); // whitelisted — should not be written to LRU
+    expect(metrics.hosts.get('a')).toEqual(undefined); // never stored
     expect(metrics.getHostInfo('a')).toEqual(ActorStatus.Whitelisted); // no history required
     metrics.trackHost('b');
     expect(typeof metrics.getHostInfo('b')).toEqual('object');
@@ -163,7 +164,8 @@ describe('getIpInfo', () => {
 
   it('returns whitelisted if in list', () => {
     const metrics = new Metrics({ ipWhitelist: new Set(['a']), minIpRate: 1, maxIpRate: 1 });
-    metrics.trackIp('a'); // would not normally be tracked if whitelisted, but no affect
+    metrics.trackIp('a'); // whitelisted — should not be written to LRU
+    expect(metrics.ips.get('a')).toEqual(undefined); // never stored
     expect(metrics.getIpInfo('a')).toEqual(ActorStatus.Whitelisted); // no history required
     metrics.trackIp('b');
     expect(typeof metrics.getIpInfo('b')).toEqual('object');


### PR DESCRIPTION
## Summary

This PR addresses seven bugs found during a comprehensive security and correctness audit of the library. Several of these have direct security implications for DDoS protection effectiveness.

### Critical fixes

- **`errorResponseDelay` was completely non-functional** (`connect.ts`) — Operator precedence bug: `return void self.#errorResponseDelay ? A : B` parses as `return (void ...) ? A : B = undefined ? A : B`, so `B` (`sendError`) always fired immediately and `A` (`setTimeout`) was unreachable. Fixed by adding parentheses around the ternary: `return void (delay ? setTimeout(...) : sendError(res))`.

- **`x-forwarded-for` multi-value bypass** (`util.ts`) — The raw header value was used as the rate-limit key. An attacker behind a proxy could rotate the left-hand IP on every request (`"1.2.3.4, proxy"` vs `"1.2.3.5, proxy"`) to reset their rate counter, completely bypassing IP and subnet throttling. Fixed by extracting only the first IP via `.split(',')[0].trim()`.

- **HTTP/1.1 TLS connections used wrong proxy flag** (`connect.ts`) — `resolveIp` detected HTTPS via `(req as Http2ServerRequest).scheme === 'https'`, which only exists on HTTP/2 requests. HTTP/1.1 TLS connections always fell through to `httpBehindProxy`. If `httpBehindProxy: true` (e.g. for HAProxy HTTP traffic) but `httpsBehindProxy: false`, QOS trusted `x-forwarded-for` for direct HTTPS connections — allowing IP spoofing. This was the root cause of the `node-dps-server` workaround that explicitly overwrote `x-forwarded-for` before calling QOS. Fixed by also checking `socket.encrypted`, which Node.js sets on `TLSSocket` instances.

- **`minLag >= maxLag` produced negative `lagRatio`** (`connect.ts`) — With inverted lag bounds, `lagRatio = (lag - minLag) / lagRange` would be negative, causing `dynamicRate` to _increase_ under load — the protection would invert at the worst possible time. Added a constructor validation to throw if `minLag >= maxLag`, consistent with the existing rate validations.

### Important fixes

- **`hostRatioRequestHistory` allocated two arrays per request** (`metrics.ts`) — `concat()` + `filter()` on every `trackHost` call created two new arrays. Under a large DDoS, this caused unnecessary GC pressure in the hottest path. Replaced with in-place `push()` + `splice()`, computing `Date.now()` once per call.

- **`trackHost` and `trackIp` lacked whitelist guards** (`metrics.ts`) — `trackSubnet` had an early-exit guard to prevent whitelisted sources from being written to the LRU. `trackHost` and `trackIp` did not, so whitelisted actors consumed LRU slots that could otherwise track real attackers. Fixed to match `trackSubnet` behaviour. The redundant inner whitelist check inside the host-ratio block was also removed since the top-level guard makes it unreachable.

- **`getHostStatus` called `toobusy.lag()` before whitelist check** (`connect.ts`) — The whitelist short-circuit happened _after_ `getStatus` (which invokes `toobusy.lag()`) was called. For whitelisted hosts under high traffic this is a wasted syscall on every request. Moved the `Whitelisted` check before `getStatus`.

## Test plan

- [ ] All 86 tests pass (`npm test`)
- [ ] `errorResponseDelay` test verifies `end()` is deferred via `jest.useFakeTimers()`
- [ ] New tests confirm first-IP extraction from comma-separated XFF headers
- [ ] New tests cover `socket.encrypted` detection for HTTP/1.1 TLS (both directions)
- [ ] New tests confirm `minLag >= maxLag` throws on construction
- [ ] Whitelist guard tests updated to assert LRU is never written for whitelisted hosts/IPs

🤖 Generated with [Claude Code](https://claude.com/claude-code)