### PR TITLE
feat: cluster-wide rate limiting via Redis sorted sets (ClusterSync)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,48 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+
+      - run: npm ci
+
+      - run: npm test
+
+  integration:
+    runs-on: ubuntu-latest
+
+    services:
+      redis:
+        image: redis:7-alpine
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 5s
+          --health-timeout 3s
+          --health-retries 5
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+
+      - run: npm ci
+
+      - run: npm run test:integration

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 5.7.0
+## Unreleased (5.7.0)
 
 - **Feature** Add cluster-wide rate limiting via shared Redis/Valkey sorted sets (`ClusterSync`)
 - **Feature** Add `onTrack` callback to `Metrics` for cross-cutting visibility into per-request actor tracking

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 5.7.0
+
+- **Feature** Add cluster-wide rate limiting via shared Redis/Valkey sorted sets (`ClusterSync`)
+- **Feature** Add `onTrack` callback to `Metrics` for cross-cutting visibility into per-request actor tracking
+- **Feature** Export `ClusterSync`, `ClusterSyncOptions`, `ClusterSyncStats`, `ClusterRedisOptions`, `ActorType` from package index
+- **Dependency** `ioredis >=5.0.0` added as an optional peer dependency (only required when using cluster mode)
+
 ## 5.6.0
 
 - **Feature** Add support for subnet blocking

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased (5.7.0)
+## 5.7.0
 
 - **Feature** Add cluster-wide rate limiting via shared Redis/Valkey sorted sets (`ClusterSync`)
 - **Feature** Add `onTrack` callback to `Metrics` for cross-cutting visibility into per-request actor tracking

--- a/README.md
+++ b/README.md
@@ -176,8 +176,8 @@ process.on('SIGTERM', () => qos.destroy());
 | `clusterMaxIpRate` | `0` (disabled) | Cluster-wide IP rate limit (req/s); 0 disables |
 | `clusterMaxSubnetRate` | `0` (disabled) | Cluster-wide /24 subnet rate limit (req/s) |
 | `clusterMaxHostRatio` | `0` (disabled) | Block host if it exceeds this fraction of total cluster traffic |
-| `clusterMaxIpRateHostViolation` | `0` (disabled) | Per-IP rate limit when the target host has a cluster violation |
-| `clusterMaxSubnetRateHostViolation` | `0` (disabled) | Per-subnet rate limit when the target host has a cluster violation |
+| `clusterMaxIpRateHostViolation` | `0` (disabled) | Per-IP rate limit when the target host has a cluster violation. **Requires local IP tracking to be enabled** (`minIpRate > 0`); enforced via local `Metrics` history, so it has no effect when local tracking is disabled. |
+| `clusterMaxSubnetRateHostViolation` | `0` (disabled) | Per-subnet rate limit when the target host has a cluster violation. **Requires local subnet tracking to be enabled** (`minSubnetRate > 0`); same constraint as above. |
 | `onSync` | — | Callback after each sync cycle; receives `ClusterSyncStats` |
 | `onError` | — | Callback on Redis sync errors (non-fatal; node continues operating) |
 

--- a/README.md
+++ b/README.md
@@ -189,10 +189,6 @@ QOS sorted-set keys have no TTL. Use a dedicated Redis/Valkey instance with `max
 
 Call `qos.destroy()` to stop the background sync interval. The interval is created with `.unref()` so it will not prevent the Node.js process from exiting, but explicit cleanup is still recommended for clean shutdown.
 
-### Disabling Cluster Sync at Runtime
-
-To disable cluster sync via a config merge (e.g. Switchboard), push `{ cluster: null }`. Using `undefined` is silently ignored by `lodash.mergeWith` — only `null` forces the key to falsy and disables sync.
-
 ### `onError` Callback
 
 `onError` fires on both sync failures (publish/read pipeline errors) and background cleanup errors. These are non-fatal; the node continues operating with its previous blocklist. Log all `onError` calls at `warn` level.

--- a/README.md
+++ b/README.md
@@ -124,6 +124,80 @@ For you tweakers out there, here's some levers to pull:
   if this option is set to `true`.
 
 
+## Cluster-Wide Rate Limiting
+
+`connect-qos` supports cluster-wide rate limiting via Redis for multi-node deployments behind a load balancer. Without cluster mode, each node tracks request rates independently, so a distributed attacker spreading requests across nodes evades per-node limits. With cluster mode enabled, all nodes share counts via a dedicated Redis/Valkey instance.
+
+### Enabling Cluster Mode
+
+```js
+const Redis = require('ioredis');
+const { ConnectQOS } = require('connect-qos');
+
+const redisClient = new Redis.Cluster([{ host: 'redis.example.com', port: 6379 }]);
+
+const qos = new ConnectQOS({
+  minIpRate: 8,
+  maxIpRate: 15,
+  maxAge: 10000,
+  cluster: {
+    redis: { client: redisClient, keyPrefix: 'qos:' },
+    syncIntervalMs: 2000,
+    maxTrackedActors: 50000,
+    clusterMaxIpRate: 50,
+    clusterMaxSubnetRate: 200,
+    clusterMaxHostRatio: 0.20,
+    clusterMaxIpRateHostViolation: 10,
+    clusterMaxSubnetRateHostViolation: 30,
+    onSync: (stats) => console.log('Cluster sync:', stats),
+    onError: (err) => console.error('Cluster sync error', err.message),
+  }
+});
+
+process.on('SIGTERM', () => qos.destroy());
+```
+
+### How It Works
+
+- **Zero hot-path latency**: all throttle decisions use in-process state; Redis is never on the request path
+- **Background sync**: every `syncIntervalMs`, accumulated per-actor hit deltas are published to Redis sorted sets and cluster-wide counts are read back
+- **Sliding window**: rate is computed from the current + previous time buckets to avoid boundary spikes
+- **Graceful degradation**: if Redis is unavailable, the previous blocklist remains active; the node falls back to per-node limiting until the next successful sync
+- **Delta retry**: if publishing to Redis fails, deltas are merged back into the local accumulator for the next cycle — no counts are lost
+
+### Cluster Options
+
+| Option | Default | Description |
+|---|---|---|
+| `redis.client` | required | ioredis client instance (pass `null` to disable cluster sync) |
+| `redis.keyPrefix` | `'qos:'` | Key prefix for all cluster Redis keys |
+| `syncIntervalMs` | `2000` | How often to sync with Redis (ms) |
+| `maxTrackedActors` | `50000` | Max actors per sorted set (oldest trimmed when exceeded) |
+| `clusterMaxIpRate` | `0` (disabled) | Cluster-wide IP rate limit (req/s); 0 disables |
+| `clusterMaxSubnetRate` | `0` (disabled) | Cluster-wide /24 subnet rate limit (req/s) |
+| `clusterMaxHostRatio` | `0` (disabled) | Block host if it exceeds this fraction of total cluster traffic |
+| `clusterMaxIpRateHostViolation` | `0` (disabled) | Per-IP rate limit when the target host has a cluster violation |
+| `clusterMaxSubnetRateHostViolation` | `0` (disabled) | Per-subnet rate limit when the target host has a cluster violation |
+| `onSync` | — | Callback after each sync cycle; receives `ClusterSyncStats` |
+| `onError` | — | Callback on Redis sync errors (non-fatal; node continues operating) |
+
+### Redis Eviction Safety
+
+QOS sorted-set keys have no TTL. Use a dedicated Redis/Valkey instance with `maxmemory-policy volatile-lru` so only keys with TTLs are evicted. Under `volatile-lru`, QOS keys are never evicted regardless of memory pressure.
+
+### Lifecycle
+
+Call `qos.destroy()` to stop the background sync interval. The interval is created with `.unref()` so it will not prevent the Node.js process from exiting, but explicit cleanup is still recommended for clean shutdown.
+
+### Disabling Cluster Sync at Runtime
+
+To disable cluster sync via a config merge (e.g. Switchboard), push `{ cluster: null }`. Using `undefined` is silently ignored by `lodash.mergeWith` — only `null` forces the key to falsy and disables sync.
+
+### `onError` Callback
+
+`onError` fires on both sync failures (publish/read pipeline errors) and background cleanup errors. These are non-fatal; the node continues operating with its previous blocklist. Log all `onError` calls at `warn` level.
+
+
 ## Performance
 
 With quality of service being the entire purpose of this library needless to say

--- a/README.md
+++ b/README.md
@@ -194,6 +194,28 @@ Call `qos.destroy()` to stop the background sync interval. The interval is creat
 `onError` fires on both sync failures (publish/read pipeline errors) and background cleanup errors. These are non-fatal; the node continues operating with its previous blocklist. Log all `onError` calls at `warn` level.
 
 
+## Testing
+
+Unit tests require no external dependencies:
+
+```sh
+npm test
+```
+
+Integration tests verify cluster mode against a real Redis instance. Start Redis locally, then:
+
+```sh
+npm run test:integration
+```
+
+The tests connect to `redis://localhost:6379` by default. To use a different URL:
+
+```sh
+REDIS_URL=redis://myhost:6379 npm run test:integration
+```
+
+If Redis is unreachable the suite fails immediately with a clear error rather than hanging.
+
 ## Performance
 
 With quality of service being the entire purpose of this library needless to say

--- a/README.md
+++ b/README.md
@@ -169,10 +169,10 @@ process.on('SIGTERM', () => qos.destroy());
 
 | Option | Default | Description |
 |---|---|---|
-| `redis.client` | required | ioredis client instance (pass `null` to disable cluster sync) |
+| `redis.client` | required | ioredis `Redis` or `Cluster` instance |
 | `redis.keyPrefix` | `'qos:'` | Key prefix for all cluster Redis keys |
 | `syncIntervalMs` | `2000` | How often to sync with Redis (ms) |
-| `maxTrackedActors` | `50000` | Max actors per sorted set (oldest trimmed when exceeded) |
+| `maxTrackedActors` | `50000` | Max actors tracked per sorted set window; lowest-traffic actors are removed when exceeded |
 | `clusterMaxIpRate` | `0` (disabled) | Cluster-wide IP rate limit (req/s); 0 disables |
 | `clusterMaxSubnetRate` | `0` (disabled) | Cluster-wide /24 subnet rate limit (req/s) |
 | `clusterMaxHostRatio` | `0` (disabled) | Block host if it exceeds this fraction of total cluster traffic |

--- a/README.md
+++ b/README.md
@@ -183,7 +183,10 @@ process.on('SIGTERM', () => qos.destroy());
 
 ### Redis Eviction Safety
 
-QOS sorted-set keys have no TTL. Use a dedicated Redis/Valkey instance with `maxmemory-policy volatile-lru` so only keys with TTLs are evicted. Under `volatile-lru`, QOS keys are never evicted regardless of memory pressure.
+QOS sorted-set keys have no TTL. Under `volatile-*` eviction policies, only keys **with** TTLs are eligible for eviction — keys without TTLs are never evicted but also never safe: once `maxmemory` is exhausted, Redis returns OOM errors for write commands instead of evicting. To avoid OOM errors, either:
+
+- Use a **dedicated** Redis/Valkey instance with enough memory that eviction is never needed (recommended), or
+- Use `maxmemory-policy allkeys-lru` so Redis can evict the lowest-traffic QOS keys when memory pressure is high (graceful degradation: old windows are evicted first, which is acceptable behavior).
 
 ### Lifecycle
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "@types/jest": "^29.5.12",
         "@types/node": "^20.14.10",
         "chokidar": "3.5.3",
+        "ioredis": "^5.9.0",
         "jest": "^29.7.0",
         "rimraf": "3.0.2",
         "ts-jest": "^29.2.2",
@@ -31,6 +32,14 @@
       },
       "optionalDependencies": {
         "@swc/core-linux-x64-gnu": "^1.2.229"
+      },
+      "peerDependencies": {
+        "ioredis": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ioredis": {
+          "optional": true
+        }
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -650,6 +659,13 @@
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
+    },
+    "node_modules/@ioredis/commands": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.10.0.tgz",
+      "integrity": "sha512-UmeW7z4LfctwoQ5wkhVzgq8tXkreED2xZGpX+Bg+zA+WJFZCT6c062AfCK/Dfk81xZnnwdhJCUMkitihRaoC2Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
@@ -2261,6 +2277,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/cluster-key-slot": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.1.tgz",
+      "integrity": "sha512-rwHwUfXL40Chm1r08yrhU3qpUvdVlgkKNeyeGPOxnW8/SyVDvgRaed/Uz54AqWNaTCAThlj6QAs3TZcKI0xDEw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -2383,12 +2409,13 @@
       "dev": true
     },
     "node_modules/debug": {
-      "version": "4.3.5",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.5.tgz",
-      "integrity": "sha512-pt0bNEmneDIvdL1Xsd9oDQ/wrQRkXDT4AUWlNZNPKvW5x/jyO9VFXkJUP07vQ2upmw5PlaITaPKc31jK13V+jg==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "ms": "2.1.2"
+        "ms": "^2.1.3"
       },
       "engines": {
         "node": ">=6.0"
@@ -2456,6 +2483,16 @@
       "dev": true,
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/denque": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
+      "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10"
       }
     },
     "node_modules/detect-newline": {
@@ -3064,6 +3101,29 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true
+    },
+    "node_modules/ioredis": {
+      "version": "5.11.1",
+      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.11.1.tgz",
+      "integrity": "sha512-ehuGcf94bQXhfagULNXrJdfnWO38v070jxSx/qE87Kjzmu2fU7ro5EFAb+OPituLqgfyuQaym5DlrNydW2sJ9A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ioredis/commands": "1.10.0",
+        "cluster-key-slot": "1.1.1",
+        "debug": "4.4.3",
+        "denque": "2.1.0",
+        "redis-errors": "1.2.0",
+        "redis-parser": "3.0.0",
+        "standard-as-callback": "2.1.0"
+      },
+      "engines": {
+        "node": ">=12.22.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/ioredis"
+      }
     },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
@@ -4163,10 +4223,11 @@
       }
     },
     "node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
@@ -4630,6 +4691,29 @@
         "node": ">=8.10.0"
       }
     },
+    "node_modules/redis-errors": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
+      "integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/redis-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
+      "integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "redis-errors": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -4943,6 +5027,13 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/standard-as-callback": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
+      "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/string_decoder": {
       "version": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,14 @@
     "lru-cache": "^7.14.1",
     "toobusy-js": "^0.5.1"
   },
+  "peerDependencies": {
+    "ioredis": ">=5.0.0"
+  },
+  "peerDependenciesMeta": {
+    "ioredis": {
+      "optional": true
+    }
+  },
   "devDependencies": {
     "@swc/cli": "^0.4.0",
     "@swc/core": "^1.6.13",
@@ -52,6 +60,7 @@
     "@types/jest": "^29.5.12",
     "@types/node": "^20.14.10",
     "chokidar": "3.5.3",
+    "ioredis": "^5.9.0",
     "jest": "^29.7.0",
     "rimraf": "3.0.2",
     "ts-jest": "^29.2.2",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "build": "npx rimraf ./lib && swc src/* --strip-leading-paths --out-dir lib",
     "prepublish": "npm run build",
     "test": "jest",
+    "test:integration": "REDIS_URL=redis://localhost:6379 jest test/integration.test.ts --testTimeout=10000",
     "watch": "swc src --out-dir lib -w"
   },
   "files": [

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build": "npx rimraf ./lib && swc src/* --strip-leading-paths --out-dir lib",
     "prepublish": "npm run build",
     "test": "jest",
-    "test:integration": "REDIS_URL=redis://localhost:6379 jest test/integration.test.ts --testTimeout=10000 --forceExit",
+    "test:integration": "REDIS_URL=redis://localhost:6379 jest test/integration.test.ts --testTimeout=10000 --detectOpenHandles",
     "watch": "swc src --out-dir lib -w"
   },
   "files": [

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build": "npx rimraf ./lib && swc src/* --strip-leading-paths --out-dir lib",
     "prepublish": "npm run build",
     "test": "jest",
-    "test:integration": "REDIS_URL=redis://localhost:6379 jest test/integration.test.ts --testTimeout=10000",
+    "test:integration": "REDIS_URL=redis://localhost:6379 jest test/integration.test.ts --testTimeout=10000 --forceExit",
     "watch": "swc src --out-dir lib -w"
   },
   "files": [

--- a/src/cluster.ts
+++ b/src/cluster.ts
@@ -219,15 +219,16 @@ export class ClusterSync {
     hostDeltas: Map<string, number>,
     totalDelta: number
   ): void {
-    for (const [key, count] of ipDeltas) {
-      this.#ipDeltas.set(key, (this.#ipDeltas.get(key) || 0) + count);
-    }
-    for (const [key, count] of subnetDeltas) {
-      this.#subnetDeltas.set(key, (this.#subnetDeltas.get(key) || 0) + count);
-    }
-    for (const [key, count] of hostDeltas) {
-      this.#hostDeltas.set(key, (this.#hostDeltas.get(key) || 0) + count);
-    }
+    const merge = (dest: Map<string, number>, src: Map<string, number>) => {
+      for (const [key, count] of src) {
+        if (dest.size < this.#maxTrackedActors || dest.has(key)) {
+          dest.set(key, (dest.get(key) || 0) + count);
+        }
+      }
+    };
+    merge(this.#ipDeltas, ipDeltas);
+    merge(this.#subnetDeltas, subnetDeltas);
+    merge(this.#hostDeltas, hostDeltas);
     this.#totalDelta += totalDelta;
   }
 

--- a/src/cluster.ts
+++ b/src/cluster.ts
@@ -234,6 +234,15 @@ export class ClusterSync {
       pipe.incrby(this.#totalKey(window), totalDelta);
     }
 
+    // Trim sorted sets to maxTrackedActors (keep highest scores = top offenders).
+    // Only trim types with active deltas — no unnecessary pipeline commands for idle types.
+    // When the set has fewer than maxTrackedActors entries, ZREMRANGEBYRANK resolves
+    // stop to a negative index that underflows past the start and is a no-op per Redis spec.
+    const trimIndex = -(this.#maxTrackedActors + 1);
+    if (ipDeltas.size > 0) pipe.zremrangebyrank(this.#windowKey('ip', window), 0, trimIndex);
+    if (subnetDeltas.size > 0) pipe.zremrangebyrank(this.#windowKey('subnet', window), 0, trimIndex);
+    if (hostDeltas.size > 0) pipe.zremrangebyrank(this.#windowKey('host', window), 0, trimIndex);
+
     await pipe.exec();
   }
 

--- a/src/cluster.ts
+++ b/src/cluster.ts
@@ -60,16 +60,16 @@ export class ClusterSync {
 
   constructor(opts: ClusterSyncOptions) {
     this.#redis = opts.redis.client;
-    this.#keyPrefix = opts.redis.keyPrefix || DEFAULT_KEY_PREFIX;
+    this.#keyPrefix = opts.redis.keyPrefix ?? DEFAULT_KEY_PREFIX;
     // Guard against 0/negative/NaN values that would break window math (division by zero, NaN keys).
     this.#windowMs = opts.windowMs > 0 ? opts.windowMs : 10000;
     this.#syncIntervalMs = (opts.syncIntervalMs ?? 0) > 0 ? opts.syncIntervalMs! : DEFAULT_SYNC_INTERVAL_MS;
     this.#maxTrackedActors = (opts.maxTrackedActors ?? 0) > 0 ? opts.maxTrackedActors! : DEFAULT_MAX_TRACKED_ACTORS;
-    this.#clusterMaxIpRate = opts.clusterMaxIpRate || 0;
-    this.#clusterMaxSubnetRate = opts.clusterMaxSubnetRate || 0;
-    this.#clusterMaxHostRatio = opts.clusterMaxHostRatio || 0;
-    this.#clusterMaxIpRateHostViolation = opts.clusterMaxIpRateHostViolation || 0;
-    this.#clusterMaxSubnetRateHostViolation = opts.clusterMaxSubnetRateHostViolation || 0;
+    this.#clusterMaxIpRate = Math.max(0, opts.clusterMaxIpRate || 0);
+    this.#clusterMaxSubnetRate = Math.max(0, opts.clusterMaxSubnetRate || 0);
+    this.#clusterMaxHostRatio = Math.max(0, opts.clusterMaxHostRatio || 0);
+    this.#clusterMaxIpRateHostViolation = Math.max(0, opts.clusterMaxIpRateHostViolation || 0);
+    this.#clusterMaxSubnetRateHostViolation = Math.max(0, opts.clusterMaxSubnetRateHostViolation || 0);
     this.#onSync = opts.onSync;
     this.#onError = opts.onError;
   }

--- a/src/cluster.ts
+++ b/src/cluster.ts
@@ -1,0 +1,340 @@
+export interface ClusterRedisOptions {
+  client: any; // ioredis Redis or Cluster instance
+  keyPrefix?: string;
+}
+
+export interface ClusterSyncStats {
+  syncDurationMs: number;
+  blockedIps: number;
+  blockedSubnets: number;
+  hostViolations: number;
+  publishedDeltas: { ip: number; subnet: number; host: number };
+}
+
+export interface ClusterSyncOptions {
+  redis: ClusterRedisOptions;
+  windowMs: number;
+  syncIntervalMs?: number;
+  maxTrackedActors?: number;
+  clusterMinIpRate?: number;
+  clusterMaxIpRate?: number;
+  clusterMinSubnetRate?: number;
+  clusterMaxSubnetRate?: number;
+  clusterMaxHostRatio?: number;
+  clusterMaxIpRateHostViolation?: number;
+  clusterMaxSubnetRateHostViolation?: number;
+  onSync?: (stats: ClusterSyncStats) => void;
+  onError?: (err: Error) => void;
+}
+
+export type ActorType = 'ip' | 'subnet' | 'host';
+
+const DEFAULT_SYNC_INTERVAL_MS = 2000;
+const DEFAULT_MAX_TRACKED_ACTORS = 50_000;
+const DEFAULT_KEY_PREFIX = 'qos:';
+
+export class ClusterSync {
+  #redis: any;
+  #keyPrefix: string;
+  #windowMs: number;
+  #syncIntervalMs: number;
+  #maxTrackedActors: number;
+  #clusterMinIpRate: number;
+  #clusterMaxIpRate: number;
+  #clusterMinSubnetRate: number;
+  #clusterMaxSubnetRate: number;
+  #clusterMaxHostRatio: number;
+  #clusterMaxIpRateHostViolation: number;
+  #clusterMaxSubnetRateHostViolation: number;
+  #onSync?: (stats: ClusterSyncStats) => void;
+  #onError?: (err: Error) => void;
+
+  #ipDeltas = new Map<string, number>();
+  #subnetDeltas = new Map<string, number>();
+  #hostDeltas = new Map<string, number>();
+  #totalDelta = 0;
+
+  #blockedIps = new Set<string>();
+  #blockedSubnets = new Set<string>();
+  #hostViolations = new Set<string>();
+
+  #intervalHandle: ReturnType<typeof setInterval> | null = null;
+  #running = false;
+
+  constructor(opts: ClusterSyncOptions) {
+    this.#redis = opts.redis.client;
+    this.#keyPrefix = opts.redis.keyPrefix || DEFAULT_KEY_PREFIX;
+    this.#windowMs = opts.windowMs;
+    this.#syncIntervalMs = opts.syncIntervalMs || DEFAULT_SYNC_INTERVAL_MS;
+    this.#maxTrackedActors = opts.maxTrackedActors || DEFAULT_MAX_TRACKED_ACTORS;
+    this.#clusterMinIpRate = opts.clusterMinIpRate || 0;
+    this.#clusterMaxIpRate = opts.clusterMaxIpRate || 0;
+    this.#clusterMinSubnetRate = opts.clusterMinSubnetRate || 0;
+    this.#clusterMaxSubnetRate = opts.clusterMaxSubnetRate || 0;
+    this.#clusterMaxHostRatio = opts.clusterMaxHostRatio || 0;
+    this.#clusterMaxIpRateHostViolation = opts.clusterMaxIpRateHostViolation || 0;
+    this.#clusterMaxSubnetRateHostViolation = opts.clusterMaxSubnetRateHostViolation || 0;
+    this.#onSync = opts.onSync;
+    this.#onError = opts.onError;
+  }
+
+  get isRunning(): boolean {
+    return this.#running;
+  }
+
+  start(): void {
+    if (this.#running) return;
+    this.#running = true;
+    this.#intervalHandle = setInterval(() => this.#sync(), this.#syncIntervalMs);
+    this.#intervalHandle.unref();
+  }
+
+  stop(): void {
+    if (!this.#running) return;
+    this.#running = false;
+    if (this.#intervalHandle) {
+      clearInterval(this.#intervalHandle);
+      this.#intervalHandle = null;
+    }
+  }
+
+  recordHit(type: ActorType, key: string): void {
+    const deltas = this.#getDeltaMap(type);
+    if (deltas.size >= this.#maxTrackedActors && !deltas.has(key)) return;
+    deltas.set(key, (deltas.get(key) || 0) + 1);
+    if (type === 'host') this.#totalDelta++;
+  }
+
+  getAndResetDeltas(type: ActorType): Map<string, number> {
+    const deltas = this.#getDeltaMap(type);
+    const snapshot = new Map(deltas);
+    deltas.clear();
+    return snapshot;
+  }
+
+  isBlocked(type: 'ip' | 'subnet', key: string): boolean {
+    return type === 'ip'
+      ? this.#blockedIps.has(key)
+      : this.#blockedSubnets.has(key);
+  }
+
+  isHostViolation(host: string): boolean {
+    return this.#hostViolations.has(host);
+  }
+
+  get blockedIps(): Set<string> {
+    return this.#blockedIps;
+  }
+
+  get blockedSubnets(): Set<string> {
+    return this.#blockedSubnets;
+  }
+
+  get hostViolations(): Set<string> {
+    return this.#hostViolations;
+  }
+
+  get clusterMaxIpRateHostViolation(): number {
+    return this.#clusterMaxIpRateHostViolation;
+  }
+
+  get clusterMaxSubnetRateHostViolation(): number {
+    return this.#clusterMaxSubnetRateHostViolation;
+  }
+
+  #getDeltaMap(type: ActorType): Map<string, number> {
+    switch (type) {
+      case 'ip': return this.#ipDeltas;
+      case 'subnet': return this.#subnetDeltas;
+      case 'host': return this.#hostDeltas;
+    }
+  }
+
+  #currentWindow(): number {
+    return Math.floor(Date.now() / this.#windowMs);
+  }
+
+  #windowKey(type: ActorType, window: number): string {
+    return `${this.#keyPrefix}${type}:w${window}`;
+  }
+
+  #totalKey(window: number): string {
+    return `${this.#keyPrefix}total:w${window}`;
+  }
+
+  async #sync(): Promise<void> {
+    const start = Date.now();
+    // Snapshot all deltas synchronously before the first await.
+    // JS is single-threaded so no recordHit can interleave during these assignments.
+    const ipDeltas = this.getAndResetDeltas('ip');
+    const subnetDeltas = this.getAndResetDeltas('subnet');
+    const totalDelta = this.#totalDelta;
+    this.#totalDelta = 0;
+    const hostDeltas = this.getAndResetDeltas('host');
+
+    try {
+      await this.#publishDeltas(ipDeltas, subnetDeltas, hostDeltas, totalDelta);
+      await this.#readThresholds();
+      this.#cleanupOldWindows();
+      this.#onSync?.({
+        syncDurationMs: Date.now() - start,
+        blockedIps: this.#blockedIps.size,
+        blockedSubnets: this.#blockedSubnets.size,
+        hostViolations: this.#hostViolations.size,
+        publishedDeltas: { ip: ipDeltas.size, subnet: subnetDeltas.size, host: hostDeltas.size },
+      });
+    } catch (err) {
+      // Merge deltas back so they're retried on the next sync cycle
+      // rather than being silently lost on transient Redis failures.
+      this.#mergeDeltasBack(ipDeltas, subnetDeltas, hostDeltas, totalDelta);
+      this.#onError?.(err as Error);
+    }
+  }
+
+  #mergeDeltasBack(
+    ipDeltas: Map<string, number>,
+    subnetDeltas: Map<string, number>,
+    hostDeltas: Map<string, number>,
+    totalDelta: number
+  ): void {
+    for (const [key, count] of ipDeltas) {
+      this.#ipDeltas.set(key, (this.#ipDeltas.get(key) || 0) + count);
+    }
+    for (const [key, count] of subnetDeltas) {
+      this.#subnetDeltas.set(key, (this.#subnetDeltas.get(key) || 0) + count);
+    }
+    for (const [key, count] of hostDeltas) {
+      this.#hostDeltas.set(key, (this.#hostDeltas.get(key) || 0) + count);
+    }
+    this.#totalDelta += totalDelta;
+  }
+
+  async #publishDeltas(
+    ipDeltas: Map<string, number>,
+    subnetDeltas: Map<string, number>,
+    hostDeltas: Map<string, number>,
+    totalDelta: number
+  ): Promise<void> {
+    const window = this.#currentWindow();
+
+    if (ipDeltas.size === 0 && subnetDeltas.size === 0 && hostDeltas.size === 0) return;
+
+    const pipe = this.#redis.pipeline();
+
+    for (const [key, count] of ipDeltas) {
+      pipe.zincrby(this.#windowKey('ip', window), count, key);
+    }
+    for (const [key, count] of subnetDeltas) {
+      pipe.zincrby(this.#windowKey('subnet', window), count, key);
+    }
+    for (const [key, count] of hostDeltas) {
+      pipe.zincrby(this.#windowKey('host', window), count, key);
+    }
+    if (totalDelta > 0) {
+      pipe.incrby(this.#totalKey(window), totalDelta);
+    }
+
+    await pipe.exec();
+  }
+
+  async #readThresholds(): Promise<void> {
+    if (this.#clusterMaxIpRate === 0 && this.#clusterMaxSubnetRate === 0 && this.#clusterMaxHostRatio === 0) return;
+    const window = this.#currentWindow();
+    const prevWindow = window - 1;
+    const pipe = this.#redis.pipeline();
+
+    const ipThreshold = this.#clusterMaxIpRate > 0
+      ? Math.ceil(this.#clusterMaxIpRate * (this.#windowMs / 1000))
+      : 0;
+    const subnetThreshold = this.#clusterMaxSubnetRate > 0
+      ? Math.ceil(this.#clusterMaxSubnetRate * (this.#windowMs / 1000))
+      : 0;
+
+    if (ipThreshold > 0) {
+      pipe.zrangebyscore(this.#windowKey('ip', window), ipThreshold, '+inf');
+      pipe.zrangebyscore(this.#windowKey('ip', prevWindow), ipThreshold, '+inf');
+    }
+    if (subnetThreshold > 0) {
+      pipe.zrangebyscore(this.#windowKey('subnet', window), subnetThreshold, '+inf');
+      pipe.zrangebyscore(this.#windowKey('subnet', prevWindow), subnetThreshold, '+inf');
+    }
+    if (this.#clusterMaxHostRatio > 0) {
+      pipe.get(this.#totalKey(window));
+      pipe.get(this.#totalKey(prevWindow));
+      const minHostCount = Math.max(1, Math.ceil(this.#clusterMaxHostRatio * 0.5 * (this.#windowMs / 1000)));
+      pipe.zrangebyscore(this.#windowKey('host', window), minHostCount, '+inf', 'WITHSCORES');
+      pipe.zrangebyscore(this.#windowKey('host', prevWindow), minHostCount, '+inf', 'WITHSCORES');
+    }
+
+    const results = await pipe.exec();
+    if (!results || results.length === 0) return;
+
+    let idx = 0;
+
+    // Process IP blocks
+    if (ipThreshold > 0) {
+      const currentIps: string[] = results[idx]?.[1] || [];
+      const prevIps: string[] = results[idx + 1]?.[1] || [];
+      idx += 2;
+      const newBlockedIps = new Set<string>();
+      for (const ip of currentIps) newBlockedIps.add(ip);
+      for (const ip of prevIps) newBlockedIps.add(ip);
+      this.#blockedIps = newBlockedIps;
+    }
+
+    // Process subnet blocks
+    if (subnetThreshold > 0) {
+      const currentSubnets: string[] = results[idx]?.[1] || [];
+      const prevSubnets: string[] = results[idx + 1]?.[1] || [];
+      idx += 2;
+      const newBlockedSubnets = new Set<string>();
+      for (const subnet of currentSubnets) newBlockedSubnets.add(subnet);
+      for (const subnet of prevSubnets) newBlockedSubnets.add(subnet);
+      this.#blockedSubnets = newBlockedSubnets;
+    }
+
+    // Process host ratio violations
+    if (this.#clusterMaxHostRatio > 0) {
+      const currentTotal = parseInt(results[idx]?.[1] || '0', 10);
+      const prevTotal = parseInt(results[idx + 1]?.[1] || '0', 10);
+      const currentHostScores: string[] = results[idx + 2]?.[1] || [];
+      const prevHostScores: string[] = results[idx + 3]?.[1] || [];
+      idx += 4;
+
+      const newHostViolations = new Set<string>();
+      const totalRequests = currentTotal + prevTotal;
+
+      if (totalRequests > 0) {
+        // WITHSCORES returns alternating [member, score, member, score, ...]
+        const hostCounts = new Map<string, number>();
+        for (let i = 0; i < currentHostScores.length; i += 2) {
+          const host = currentHostScores[i];
+          const count = parseInt(currentHostScores[i + 1], 10);
+          hostCounts.set(host, (hostCounts.get(host) || 0) + count);
+        }
+        for (let i = 0; i < prevHostScores.length; i += 2) {
+          const host = prevHostScores[i];
+          const count = parseInt(prevHostScores[i + 1], 10);
+          hostCounts.set(host, (hostCounts.get(host) || 0) + count);
+        }
+        for (const [host, count] of hostCounts) {
+          if (count / totalRequests > this.#clusterMaxHostRatio) {
+            newHostViolations.add(host);
+          }
+        }
+      }
+      this.#hostViolations = newHostViolations;
+    }
+  }
+
+  #cleanupOldWindows(): void {
+    const currentWindow = this.#currentWindow();
+    const staleWindow = currentWindow - 3; // clean windows older than 3× windowMs
+    const pipe = this.#redis.pipeline();
+    for (const type of ['ip', 'subnet', 'host'] as ActorType[]) {
+      pipe.unlink(this.#windowKey(type, staleWindow));
+    }
+    pipe.unlink(this.#totalKey(staleWindow));
+    pipe.exec().catch((err: Error) => this.#onError?.(err));
+  }
+}

--- a/src/cluster.ts
+++ b/src/cluster.ts
@@ -1,5 +1,21 @@
+// Minimal interface covering only the ioredis methods ClusterSync actually calls.
+// Avoids a hard dependency on ioredis types while still providing useful type checking.
+export interface RedisPipeline {
+  zincrby(key: string, increment: number, member: string): this;
+  zrangebyscore(key: string, min: number | string, max: number | string, ...args: string[]): this;
+  zremrangebyrank(key: string, start: number, stop: number): this;
+  incrby(key: string, increment: number): this;
+  get(key: string): this;
+  unlink(...keys: string[]): this;
+  exec(): Promise<Array<[Error | null, unknown]> | null>;
+}
+
+export interface RedisLike {
+  pipeline(): RedisPipeline;
+}
+
 export interface ClusterRedisOptions {
-  client: any; // ioredis Redis or Cluster instance
+  client: RedisLike;
   keyPrefix?: string;
 }
 
@@ -32,7 +48,7 @@ const DEFAULT_MAX_TRACKED_ACTORS = 50_000;
 const DEFAULT_KEY_PREFIX = 'qos:';
 
 export class ClusterSync {
-  #redis: any;
+  #redis: RedisLike;
   #keyPrefix: string;
   #windowMs: number;
   #syncIntervalMs: number;

--- a/src/cluster.ts
+++ b/src/cluster.ts
@@ -281,7 +281,8 @@ export class ClusterSync {
     if (hostDeltas.size > 0) pipe.zremrangebyrank(this.#windowKey('host', win), 0, trimIndex);
 
     const results = await pipe.exec();
-    const firstError = results?.find(([err]: [Error | null, any]) => err)?.[0];
+    if (!results) throw new Error('Redis pipeline exec returned null');
+    const firstError = results.find(([err]: [Error | null, any]) => err)?.[0];
     if (firstError) throw firstError;
   }
 
@@ -302,15 +303,19 @@ export class ClusterSync {
       ? Math.ceil(this.#clusterMaxSubnetRate * (this.#windowMs / 1000))
       : 0;
 
-    // Fetch all actors with at least one hit in each window so the sliding window
-    // computation can correctly handle actors that straddle a window boundary.
+    // Use threshold/2 as the minimum score for each window query. This is safe: if an actor
+    // scores below threshold/2 in BOTH windows, its sliding value (current + prev*prevWeight)
+    // is at most threshold/2 + threshold/2 = threshold, so it can never exceed the threshold.
+    // Any actor that could actually be blocked appears in at least one window above this floor.
     if (ipThreshold > 0) {
-      pipe.zrangebyscore(this.#windowKey('ip', win), 1, '+inf', 'WITHSCORES');
-      pipe.zrangebyscore(this.#windowKey('ip', prevWindow), 1, '+inf', 'WITHSCORES');
+      const ipMinScore = Math.max(1, Math.floor(ipThreshold / 2));
+      pipe.zrangebyscore(this.#windowKey('ip', win), ipMinScore, '+inf', 'WITHSCORES');
+      pipe.zrangebyscore(this.#windowKey('ip', prevWindow), ipMinScore, '+inf', 'WITHSCORES');
     }
     if (subnetThreshold > 0) {
-      pipe.zrangebyscore(this.#windowKey('subnet', win), 1, '+inf', 'WITHSCORES');
-      pipe.zrangebyscore(this.#windowKey('subnet', prevWindow), 1, '+inf', 'WITHSCORES');
+      const subnetMinScore = Math.max(1, Math.floor(subnetThreshold / 2));
+      pipe.zrangebyscore(this.#windowKey('subnet', win), subnetMinScore, '+inf', 'WITHSCORES');
+      pipe.zrangebyscore(this.#windowKey('subnet', prevWindow), subnetMinScore, '+inf', 'WITHSCORES');
     }
     if (this.#clusterMaxHostRatio > 0) {
       pipe.get(this.#totalKey(win));

--- a/src/cluster.ts
+++ b/src/cluster.ts
@@ -16,9 +16,7 @@ export interface ClusterSyncOptions {
   windowMs: number;
   syncIntervalMs?: number;
   maxTrackedActors?: number;
-  clusterMinIpRate?: number;
   clusterMaxIpRate?: number;
-  clusterMinSubnetRate?: number;
   clusterMaxSubnetRate?: number;
   clusterMaxHostRatio?: number;
   clusterMaxIpRateHostViolation?: number;
@@ -39,9 +37,7 @@ export class ClusterSync {
   #windowMs: number;
   #syncIntervalMs: number;
   #maxTrackedActors: number;
-  #clusterMinIpRate: number;
   #clusterMaxIpRate: number;
-  #clusterMinSubnetRate: number;
   #clusterMaxSubnetRate: number;
   #clusterMaxHostRatio: number;
   #clusterMaxIpRateHostViolation: number;
@@ -67,9 +63,7 @@ export class ClusterSync {
     this.#windowMs = opts.windowMs;
     this.#syncIntervalMs = opts.syncIntervalMs || DEFAULT_SYNC_INTERVAL_MS;
     this.#maxTrackedActors = opts.maxTrackedActors || DEFAULT_MAX_TRACKED_ACTORS;
-    this.#clusterMinIpRate = opts.clusterMinIpRate || 0;
     this.#clusterMaxIpRate = opts.clusterMaxIpRate || 0;
-    this.#clusterMinSubnetRate = opts.clusterMinSubnetRate || 0;
     this.#clusterMaxSubnetRate = opts.clusterMaxSubnetRate || 0;
     this.#clusterMaxHostRatio = opts.clusterMaxHostRatio || 0;
     this.#clusterMaxIpRateHostViolation = opts.clusterMaxIpRateHostViolation || 0;

--- a/src/cluster.ts
+++ b/src/cluster.ts
@@ -56,6 +56,7 @@ export class ClusterSync {
 
   #intervalHandle: ReturnType<typeof setInterval> | null = null;
   #running = false;
+  #syncing = false; // guard against overlapping sync cycles
 
   constructor(opts: ClusterSyncOptions) {
     this.#redis = opts.redis.client;
@@ -79,7 +80,10 @@ export class ClusterSync {
   start(): void {
     if (this.#running) return;
     this.#running = true;
-    this.#intervalHandle = setInterval(() => this.#sync(), this.#syncIntervalMs);
+    this.#intervalHandle = setInterval(() => {
+      if (this.#syncing) return; // skip tick if previous sync is still in-flight
+      this.#sync();
+    }, this.#syncIntervalMs);
     this.#intervalHandle.unref();
   }
 
@@ -93,10 +97,12 @@ export class ClusterSync {
   }
 
   recordHit(type: ActorType, key: string): void {
+    // Always count total traffic regardless of per-host cardinality cap so the
+    // denominator used for host ratio calculation stays accurate.
+    if (type === 'host') this.#totalDelta++;
     const deltas = this.#getDeltaMap(type);
     if (deltas.size >= this.#maxTrackedActors && !deltas.has(key)) return;
     deltas.set(key, (deltas.get(key) || 0) + 1);
-    if (type === 'host') this.#totalDelta++;
   }
 
   getAndResetDeltas(type: ActorType): Map<string, number> {
@@ -148,6 +154,12 @@ export class ClusterSync {
     return Math.floor(Date.now() / this.#windowMs);
   }
 
+  // Fraction of the current window that has elapsed (0 at window start, 1 at window end).
+  // Used to weight the previous window's contribution in the sliding window rate estimate.
+  #currentWindowOffset(): number {
+    return (Date.now() % this.#windowMs) / this.#windowMs;
+  }
+
   #windowKey(type: ActorType, window: number): string {
     return `${this.#keyPrefix}${type}:w${window}`;
   }
@@ -157,6 +169,7 @@ export class ClusterSync {
   }
 
   async #sync(): Promise<void> {
+    this.#syncing = true;
     const start = Date.now();
     // Snapshot all deltas synchronously before the first await.
     // JS is single-threaded so no recordHit can interleave during these assignments.
@@ -182,6 +195,8 @@ export class ClusterSync {
       // rather than being silently lost on transient Redis failures.
       this.#mergeDeltasBack(ipDeltas, subnetDeltas, hostDeltas, totalDelta);
       this.#onError?.(err as Error);
+    } finally {
+      this.#syncing = false;
     }
   }
 
@@ -237,13 +252,19 @@ export class ClusterSync {
     if (subnetDeltas.size > 0) pipe.zremrangebyrank(this.#windowKey('subnet', window), 0, trimIndex);
     if (hostDeltas.size > 0) pipe.zremrangebyrank(this.#windowKey('host', window), 0, trimIndex);
 
-    await pipe.exec();
+    const results = await pipe.exec();
+    const firstError = results?.find(([err]: [Error | null, any]) => err)?.[0];
+    if (firstError) throw firstError;
   }
 
   async #readThresholds(): Promise<void> {
     if (this.#clusterMaxIpRate === 0 && this.#clusterMaxSubnetRate === 0 && this.#clusterMaxHostRatio === 0) return;
     const window = this.#currentWindow();
     const prevWindow = window - 1;
+    // Sliding window weight: how much of the previous window still counts.
+    // At offset=0 (window just started) the full previous window is included;
+    // at offset=1 (window about to end) the previous window contributes nothing.
+    const prevWeight = 1 - this.#currentWindowOffset();
     const pipe = this.#redis.pipeline();
 
     const ipThreshold = this.#clusterMaxIpRate > 0
@@ -253,13 +274,15 @@ export class ClusterSync {
       ? Math.ceil(this.#clusterMaxSubnetRate * (this.#windowMs / 1000))
       : 0;
 
+    // Fetch all actors with at least one hit in each window so the sliding window
+    // computation can correctly handle actors that straddle a window boundary.
     if (ipThreshold > 0) {
-      pipe.zrangebyscore(this.#windowKey('ip', window), ipThreshold, '+inf');
-      pipe.zrangebyscore(this.#windowKey('ip', prevWindow), ipThreshold, '+inf');
+      pipe.zrangebyscore(this.#windowKey('ip', window), 1, '+inf', 'WITHSCORES');
+      pipe.zrangebyscore(this.#windowKey('ip', prevWindow), 1, '+inf', 'WITHSCORES');
     }
     if (subnetThreshold > 0) {
-      pipe.zrangebyscore(this.#windowKey('subnet', window), subnetThreshold, '+inf');
-      pipe.zrangebyscore(this.#windowKey('subnet', prevWindow), subnetThreshold, '+inf');
+      pipe.zrangebyscore(this.#windowKey('subnet', window), 1, '+inf', 'WITHSCORES');
+      pipe.zrangebyscore(this.#windowKey('subnet', prevWindow), 1, '+inf', 'WITHSCORES');
     }
     if (this.#clusterMaxHostRatio > 0) {
       pipe.get(this.#totalKey(window));
@@ -272,27 +295,56 @@ export class ClusterSync {
     const results = await pipe.exec();
     if (!results || results.length === 0) return;
 
+    const firstError = results.find(([err]: [Error | null, any]) => err)?.[0];
+    if (firstError) throw firstError;
+
     let idx = 0;
 
-    // Process IP blocks
+    // Process IP blocks using sliding window: current + prev * prevWeight >= threshold
     if (ipThreshold > 0) {
-      const currentIps: string[] = results[idx]?.[1] || [];
-      const prevIps: string[] = results[idx + 1]?.[1] || [];
+      const currentScores: string[] = results[idx]?.[1] || [];
+      const prevScores: string[] = results[idx + 1]?.[1] || [];
       idx += 2;
+
+      const currentCounts = new Map<string, number>();
+      for (let i = 0; i < currentScores.length; i += 2) {
+        currentCounts.set(currentScores[i], parseFloat(currentScores[i + 1]));
+      }
+      const prevCounts = new Map<string, number>();
+      for (let i = 0; i < prevScores.length; i += 2) {
+        prevCounts.set(prevScores[i], parseFloat(prevScores[i + 1]));
+      }
+
       const newBlockedIps = new Set<string>();
-      for (const ip of currentIps) newBlockedIps.add(ip);
-      for (const ip of prevIps) newBlockedIps.add(ip);
+      const candidates = new Set([...currentCounts.keys(), ...prevCounts.keys()]);
+      for (const ip of candidates) {
+        const sliding = (currentCounts.get(ip) || 0) + (prevCounts.get(ip) || 0) * prevWeight;
+        if (sliding >= ipThreshold) newBlockedIps.add(ip);
+      }
       this.#blockedIps = newBlockedIps;
     }
 
-    // Process subnet blocks
+    // Process subnet blocks using sliding window
     if (subnetThreshold > 0) {
-      const currentSubnets: string[] = results[idx]?.[1] || [];
-      const prevSubnets: string[] = results[idx + 1]?.[1] || [];
+      const currentScores: string[] = results[idx]?.[1] || [];
+      const prevScores: string[] = results[idx + 1]?.[1] || [];
       idx += 2;
+
+      const currentCounts = new Map<string, number>();
+      for (let i = 0; i < currentScores.length; i += 2) {
+        currentCounts.set(currentScores[i], parseFloat(currentScores[i + 1]));
+      }
+      const prevCounts = new Map<string, number>();
+      for (let i = 0; i < prevScores.length; i += 2) {
+        prevCounts.set(prevScores[i], parseFloat(prevScores[i + 1]));
+      }
+
       const newBlockedSubnets = new Set<string>();
-      for (const subnet of currentSubnets) newBlockedSubnets.add(subnet);
-      for (const subnet of prevSubnets) newBlockedSubnets.add(subnet);
+      const candidates = new Set([...currentCounts.keys(), ...prevCounts.keys()]);
+      for (const subnet of candidates) {
+        const sliding = (currentCounts.get(subnet) || 0) + (prevCounts.get(subnet) || 0) * prevWeight;
+        if (sliding >= subnetThreshold) newBlockedSubnets.add(subnet);
+      }
       this.#blockedSubnets = newBlockedSubnets;
     }
 
@@ -305,23 +357,24 @@ export class ClusterSync {
       idx += 4;
 
       const newHostViolations = new Set<string>();
-      const totalRequests = currentTotal + prevTotal;
+      // Apply the same sliding window weighting to both host counts and total traffic.
+      const slidingTotal = currentTotal + prevTotal * prevWeight;
 
-      if (totalRequests > 0) {
+      if (slidingTotal > 0) {
         // WITHSCORES returns alternating [member, score, member, score, ...]
-        const hostCounts = new Map<string, number>();
+        const currentHostCounts = new Map<string, number>();
         for (let i = 0; i < currentHostScores.length; i += 2) {
-          const host = currentHostScores[i];
-          const count = parseInt(currentHostScores[i + 1], 10);
-          hostCounts.set(host, (hostCounts.get(host) || 0) + count);
+          currentHostCounts.set(currentHostScores[i], parseInt(currentHostScores[i + 1], 10));
         }
+        const prevHostCounts = new Map<string, number>();
         for (let i = 0; i < prevHostScores.length; i += 2) {
-          const host = prevHostScores[i];
-          const count = parseInt(prevHostScores[i + 1], 10);
-          hostCounts.set(host, (hostCounts.get(host) || 0) + count);
+          prevHostCounts.set(prevHostScores[i], parseInt(prevHostScores[i + 1], 10));
         }
-        for (const [host, count] of hostCounts) {
-          if (count / totalRequests > this.#clusterMaxHostRatio) {
+
+        const candidates = new Set([...currentHostCounts.keys(), ...prevHostCounts.keys()]);
+        for (const host of candidates) {
+          const sliding = (currentHostCounts.get(host) || 0) + (prevHostCounts.get(host) || 0) * prevWeight;
+          if (sliding / slidingTotal > this.#clusterMaxHostRatio) {
             newHostViolations.add(host);
           }
         }

--- a/src/cluster.ts
+++ b/src/cluster.ts
@@ -320,13 +320,17 @@ export class ClusterSync {
     if (this.#clusterMaxHostRatio > 0) {
       pipe.get(this.#totalKey(win));
       pipe.get(this.#totalKey(prevWindow));
-      const minHostCount = Math.max(1, Math.ceil(this.#clusterMaxHostRatio * 0.5 * (this.#windowMs / 1000)));
-      pipe.zrangebyscore(this.#windowKey('host', win), minHostCount, '+inf', 'WITHSCORES');
-      pipe.zrangebyscore(this.#windowKey('host', prevWindow), minHostCount, '+inf', 'WITHSCORES');
+      // Fetch all hosts with at least one hit. A time-based floor (ratio * windowMs) causes
+      // false negatives at low traffic volumes: a host with 1 hit out of 2 total (50%) would
+      // be filtered when minHostCount > 1. The ratio check below uses actual fetched totals,
+      // so the floor just needs to exclude zero-hit entries.
+      pipe.zrangebyscore(this.#windowKey('host', win), 1, '+inf', 'WITHSCORES');
+      pipe.zrangebyscore(this.#windowKey('host', prevWindow), 1, '+inf', 'WITHSCORES');
     }
 
     const results = await pipe.exec();
-    if (!results || results.length === 0) return;
+    if (!results) throw new Error('Redis pipeline exec returned null');
+    if (results.length === 0) return;
 
     const firstError = results.find(([err]: [Error | null, any]) => err)?.[0];
     if (firstError) throw firstError;

--- a/src/cluster.ts
+++ b/src/cluster.ts
@@ -61,9 +61,10 @@ export class ClusterSync {
   constructor(opts: ClusterSyncOptions) {
     this.#redis = opts.redis.client;
     this.#keyPrefix = opts.redis.keyPrefix || DEFAULT_KEY_PREFIX;
-    this.#windowMs = opts.windowMs;
-    this.#syncIntervalMs = opts.syncIntervalMs || DEFAULT_SYNC_INTERVAL_MS;
-    this.#maxTrackedActors = opts.maxTrackedActors || DEFAULT_MAX_TRACKED_ACTORS;
+    // Guard against 0/negative/NaN values that would break window math (division by zero, NaN keys).
+    this.#windowMs = opts.windowMs > 0 ? opts.windowMs : 10000;
+    this.#syncIntervalMs = (opts.syncIntervalMs ?? 0) > 0 ? opts.syncIntervalMs! : DEFAULT_SYNC_INTERVAL_MS;
+    this.#maxTrackedActors = (opts.maxTrackedActors ?? 0) > 0 ? opts.maxTrackedActors! : DEFAULT_MAX_TRACKED_ACTORS;
     this.#clusterMaxIpRate = opts.clusterMaxIpRate || 0;
     this.#clusterMaxSubnetRate = opts.clusterMaxSubnetRate || 0;
     this.#clusterMaxHostRatio = opts.clusterMaxHostRatio || 0;
@@ -179,8 +180,13 @@ export class ClusterSync {
     this.#totalDelta = 0;
     const hostDeltas = this.getAndResetDeltas('host');
 
+    let publishSucceeded = false;
     try {
       await this.#publishDeltas(ipDeltas, subnetDeltas, hostDeltas, totalDelta);
+      publishSucceeded = true;
+
+      if (!this.#running) return; // stop() was called during publish — skip remaining work
+
       await this.#readThresholds();
       this.#cleanupOldWindows();
       this.#onSync?.({
@@ -191,9 +197,11 @@ export class ClusterSync {
         publishedDeltas: { ip: ipDeltas.size, subnet: subnetDeltas.size, host: hostDeltas.size },
       });
     } catch (err) {
-      // Merge deltas back so they're retried on the next sync cycle
-      // rather than being silently lost on transient Redis failures.
-      this.#mergeDeltasBack(ipDeltas, subnetDeltas, hostDeltas, totalDelta);
+      if (!publishSucceeded) {
+        // Only re-queue deltas when publish failed. If publish succeeded but a later step
+        // (readThresholds, onSync) threw, re-queuing would double-count on the next cycle.
+        this.#mergeDeltasBack(ipDeltas, subnetDeltas, hostDeltas, totalDelta);
+      }
       this.#onError?.(err as Error);
     } finally {
       this.#syncing = false;

--- a/src/cluster.ts
+++ b/src/cluster.ts
@@ -232,10 +232,7 @@ export class ClusterSync {
     hostDeltas: Map<string, number>,
     totalDelta: number
   ): Promise<void> {
-    const window = this.#currentWindow();
-
-    if (ipDeltas.size === 0 && subnetDeltas.size === 0 && hostDeltas.size === 0) return;
-
+    if (ipDeltas.size === 0 && subnetDeltas.size === 0 && hostDeltas.size === 0 && totalDelta === 0) return;
     const pipe = this.#redis.pipeline();
 
     for (const [key, count] of ipDeltas) {

--- a/src/cluster.ts
+++ b/src/cluster.ts
@@ -81,9 +81,9 @@ export class ClusterSync {
   start(): void {
     if (this.#running) return;
     this.#running = true;
-    this.#intervalHandle = setInterval(() => {
+    this.#intervalHandle = setInterval(async () => {
       if (this.#syncing) return; // skip tick if previous sync is still in-flight
-      this.#sync();
+      await this.#sync();
     }, this.#syncIntervalMs);
     this.#intervalHandle.unref();
   }
@@ -95,6 +95,11 @@ export class ClusterSync {
       clearInterval(this.#intervalHandle);
       this.#intervalHandle = null;
     }
+  }
+
+  async sync(): Promise<void> {
+    if (this.#syncing) return;
+    await this.#sync();
   }
 
   recordHit(type: ActorType, key: string): void {
@@ -233,19 +238,20 @@ export class ClusterSync {
     totalDelta: number
   ): Promise<void> {
     if (ipDeltas.size === 0 && subnetDeltas.size === 0 && hostDeltas.size === 0 && totalDelta === 0) return;
+    const win = this.#currentWindow();
     const pipe = this.#redis.pipeline();
 
     for (const [key, count] of ipDeltas) {
-      pipe.zincrby(this.#windowKey('ip', window), count, key);
+      pipe.zincrby(this.#windowKey('ip', win), count, key);
     }
     for (const [key, count] of subnetDeltas) {
-      pipe.zincrby(this.#windowKey('subnet', window), count, key);
+      pipe.zincrby(this.#windowKey('subnet', win), count, key);
     }
     for (const [key, count] of hostDeltas) {
-      pipe.zincrby(this.#windowKey('host', window), count, key);
+      pipe.zincrby(this.#windowKey('host', win), count, key);
     }
     if (totalDelta > 0) {
-      pipe.incrby(this.#totalKey(window), totalDelta);
+      pipe.incrby(this.#totalKey(win), totalDelta);
     }
 
     // Trim sorted sets to maxTrackedActors (keep highest scores = top offenders).
@@ -253,9 +259,9 @@ export class ClusterSync {
     // When the set has fewer than maxTrackedActors entries, ZREMRANGEBYRANK resolves
     // stop to a negative index that underflows past the start and is a no-op per Redis spec.
     const trimIndex = -(this.#maxTrackedActors + 1);
-    if (ipDeltas.size > 0) pipe.zremrangebyrank(this.#windowKey('ip', window), 0, trimIndex);
-    if (subnetDeltas.size > 0) pipe.zremrangebyrank(this.#windowKey('subnet', window), 0, trimIndex);
-    if (hostDeltas.size > 0) pipe.zremrangebyrank(this.#windowKey('host', window), 0, trimIndex);
+    if (ipDeltas.size > 0) pipe.zremrangebyrank(this.#windowKey('ip', win), 0, trimIndex);
+    if (subnetDeltas.size > 0) pipe.zremrangebyrank(this.#windowKey('subnet', win), 0, trimIndex);
+    if (hostDeltas.size > 0) pipe.zremrangebyrank(this.#windowKey('host', win), 0, trimIndex);
 
     const results = await pipe.exec();
     const firstError = results?.find(([err]: [Error | null, any]) => err)?.[0];
@@ -264,8 +270,8 @@ export class ClusterSync {
 
   async #readThresholds(): Promise<void> {
     if (this.#clusterMaxIpRate === 0 && this.#clusterMaxSubnetRate === 0 && this.#clusterMaxHostRatio === 0) return;
-    const window = this.#currentWindow();
-    const prevWindow = window - 1;
+    const win = this.#currentWindow();
+    const prevWindow = win - 1;
     // Sliding window weight: how much of the previous window still counts.
     // At offset=0 (window just started) the full previous window is included;
     // at offset=1 (window about to end) the previous window contributes nothing.
@@ -282,18 +288,18 @@ export class ClusterSync {
     // Fetch all actors with at least one hit in each window so the sliding window
     // computation can correctly handle actors that straddle a window boundary.
     if (ipThreshold > 0) {
-      pipe.zrangebyscore(this.#windowKey('ip', window), 1, '+inf', 'WITHSCORES');
+      pipe.zrangebyscore(this.#windowKey('ip', win), 1, '+inf', 'WITHSCORES');
       pipe.zrangebyscore(this.#windowKey('ip', prevWindow), 1, '+inf', 'WITHSCORES');
     }
     if (subnetThreshold > 0) {
-      pipe.zrangebyscore(this.#windowKey('subnet', window), 1, '+inf', 'WITHSCORES');
+      pipe.zrangebyscore(this.#windowKey('subnet', win), 1, '+inf', 'WITHSCORES');
       pipe.zrangebyscore(this.#windowKey('subnet', prevWindow), 1, '+inf', 'WITHSCORES');
     }
     if (this.#clusterMaxHostRatio > 0) {
-      pipe.get(this.#totalKey(window));
+      pipe.get(this.#totalKey(win));
       pipe.get(this.#totalKey(prevWindow));
       const minHostCount = Math.max(1, Math.ceil(this.#clusterMaxHostRatio * 0.5 * (this.#windowMs / 1000)));
-      pipe.zrangebyscore(this.#windowKey('host', window), minHostCount, '+inf', 'WITHSCORES');
+      pipe.zrangebyscore(this.#windowKey('host', win), minHostCount, '+inf', 'WITHSCORES');
       pipe.zrangebyscore(this.#windowKey('host', prevWindow), minHostCount, '+inf', 'WITHSCORES');
     }
 

--- a/src/connect.ts
+++ b/src/connect.ts
@@ -159,8 +159,10 @@ export class ConnectQOS {
     const ipStatus = this.getIpStatus(ip, false); // defer tracking
     const subnetStatus = this.getSubnetStatus(subnet, false); // defer tracking
 
-    // never throttle whitelisted actors
-    if (hostStatus === ActorStatus.Whitelisted || ipStatus === ActorStatus.Whitelisted) return false;
+    // never throttle whitelisted actors — check sets directly so the guard works even
+    // when local tracking is disabled (minHostRate/minIpRate=0), since getInfo returns
+    // Good (not Whitelisted) when minRequests=0, bypassing the whitelist check in Metrics.
+    if (this.#metrics.hostWhitelist.has(host) || this.#metrics.ipWhitelist.has(ip)) return false;
 
     if (hostStatus === ActorStatus.Bad) return BadActorType.badHost;
 

--- a/src/connect.ts
+++ b/src/connect.ts
@@ -3,6 +3,7 @@ import { Metrics, MetricsOptions, ActorStatus, BadActorType, CacheItem } from '.
 import { IncomingMessage, ServerResponse } from 'http';
 import { Http2ServerRequest, Http2ServerResponse } from 'http2';
 import { normalizeHost, resolveHostFromRequest, resolveIpFromRequest, resolveSubnetFromIp, SubnetMaskBits } from './util';
+import { ClusterSync, ClusterSyncOptions } from './cluster';
 
 export type ConnectQOSMiddleware = (req: IncomingMessage|Http2ServerRequest, res: object, next: Function) => boolean;
 export type BeforeThrottleFn = (qos: ConnectQOS, req: IncomingMessage|Http2ServerRequest, reason: string) => boolean|undefined;
@@ -19,6 +20,7 @@ export interface ConnectQOSOptions extends MetricsOptions {
   httpBehindProxy?: boolean;
   httpsBehindProxy?: boolean;
   subnetMaskBits?: SubnetMaskBits;
+  cluster?: Omit<ClusterSyncOptions, 'windowMs'>;
 }
 
 export const DEFAULT_SUBNET_MASK_BITS: SubnetMaskBits = 24;
@@ -33,6 +35,7 @@ export class ConnectQOS {
       httpBehindProxy = false, // must be explicit to enable
       httpsBehindProxy = false, // must be explicit to enable
       subnetMaskBits = DEFAULT_SUBNET_MASK_BITS,
+      cluster,
       ...metricOptions
     } = (opts || {} as ConnectQOSOptions);
 
@@ -48,10 +51,23 @@ export class ConnectQOS {
     this.#errorResponseDelay = errorResponseDelay;
     this.#subnetMaskBits = subnetMaskBits;
 
+    if (cluster) {
+      this.#clusterSync = new ClusterSync({
+        ...cluster,
+        windowMs: metricOptions.maxAge || 10000,
+      });
+      this.#clusterSync.start();
+    }
+
     // we only require `toobusy.lag` feature and can ignore toobusy() via maxLag
     // toobusy.maxLag(this.#maxLag);
 
-    this.#metrics = new Metrics(metricOptions);
+    this.#metrics = new Metrics({
+      ...metricOptions,
+      onTrack: this.#clusterSync
+        ? (type, key) => this.#clusterSync!.recordHit(type, key)
+        : undefined,
+    });
     this.#hostRateRange = this.#metrics.maxHostRate - this.#metrics.minHostRate;
     this.#ipRateRange = this.#metrics.maxIpRate - this.#metrics.minIpRate;
     this.#subnetRateRange = this.#metrics.maxSubnetRate - this.#metrics.minSubnetRate;
@@ -69,6 +85,7 @@ export class ConnectQOS {
   #httpsBehindProxy: boolean;
   #errorResponseDelay: number;
   #metrics: Metrics;
+  #clusterSync?: ClusterSync;
 
   get minLag(): number {
     return this.#minLag;
@@ -92,6 +109,14 @@ export class ConnectQOS {
 
   get metrics(): Metrics {
     return this.#metrics;
+  }
+
+  get clusterSync(): ClusterSync | undefined {
+    return this.#clusterSync;
+  }
+
+  destroy(): void {
+    this.#clusterSync?.stop();
   }
 
   getMiddleware({ beforeThrottle, destroySocket = true }: GetMiddlewareOptions = {}) {
@@ -124,18 +149,54 @@ export class ConnectQOS {
 
   shouldThrottleRequest(req: IncomingMessage|Http2ServerRequest): BadActorType|boolean {
     const host = this.resolveHost(req);
+    const ip = this.resolveIp(req);
+    const subnet = this.resolveSubnet(req);
     const hostStatus = this.getHostStatus(host, false); // defer tracking
-    const ipStatus = this.getIpStatus(req, false); // defer tracking
-    const subnetStatus = this.getSubnetStatus(req, false); // defer tracking
+    const ipStatus = this.getIpStatus(ip, false); // defer tracking
+    const subnetStatus = this.getSubnetStatus(subnet, false); // defer tracking
 
     // never throttle whitelisted actors
     if (hostStatus === ActorStatus.Whitelisted || ipStatus === ActorStatus.Whitelisted) return false;
 
     if (hostStatus === ActorStatus.Bad) return BadActorType.badHost;
 
+    // Cluster-wide host ratio violations (checked before local IP/subnet to return hostViolation
+    // even when local IP rate limits are also exceeded)
+    if (this.#clusterSync?.isHostViolation(host)) {
+      const clusterMaxIpRateHostViolation = this.#clusterSync.clusterMaxIpRateHostViolation;
+      const clusterMaxSubnetRateHostViolation = this.#clusterSync.clusterMaxSubnetRateHostViolation;
+
+      if (!clusterMaxIpRateHostViolation && !clusterMaxSubnetRateHostViolation) {
+        return BadActorType.hostViolation;
+      }
+
+      if (clusterMaxIpRateHostViolation) {
+        const violationMin = Math.min(clusterMaxIpRateHostViolation, this.#metrics.minIpRate);
+        const violationRange = Math.max(0, clusterMaxIpRateHostViolation - violationMin);
+        if (this.getIpStatus(ip, false, violationRange, violationMin) === ActorStatus.Bad) {
+          return BadActorType.hostViolation;
+        }
+      }
+
+      if (clusterMaxSubnetRateHostViolation) {
+        const subnetViolationMin = Math.min(clusterMaxSubnetRateHostViolation, this.#metrics.minSubnetRate);
+        const subnetViolationRange = Math.max(0, clusterMaxSubnetRateHostViolation - subnetViolationMin);
+        if (this.getSubnetStatus(subnet, false, subnetViolationRange, subnetViolationMin) === ActorStatus.Bad) {
+          return BadActorType.hostViolation;
+        }
+      }
+    }
+
     if (ipStatus === ActorStatus.Bad) return BadActorType.badIp;
 
     if (subnetStatus === ActorStatus.Bad) return BadActorType.badSubnet;
+
+    // Cluster-wide checks (async-populated blocklists)
+    // Skip cluster checks for explicitly whitelisted IPs regardless of rate config
+    if (this.#clusterSync && !this.#metrics.ipWhitelist.has(ip)) {
+      if (this.#clusterSync.isBlocked('ip', ip)) return BadActorType.badIp;
+      if (this.#clusterSync.isBlocked('subnet', subnet)) return BadActorType.badSubnet;
+    }
 
     // If host is exceeding host ratio, apply per-actor rate overrides if configured
     if (this.metrics.hostRatioViolations.has(host)) {
@@ -151,7 +212,7 @@ export class ConnectQOS {
       if (maxIpRateHostViolation) {
         const violationMin = Math.min(maxIpRateHostViolation, this.#metrics.minIpRate);
         const violationRange = Math.max(0, maxIpRateHostViolation - violationMin);
-        if (this.getIpStatus(req, false, violationRange, violationMin) === ActorStatus.Bad) {
+        if (this.getIpStatus(ip, false, violationRange, violationMin) === ActorStatus.Bad) {
           return BadActorType.hostViolation;
         }
       }
@@ -160,7 +221,7 @@ export class ConnectQOS {
       if (maxSubnetRateHostViolation) {
         const subnetViolationMin = Math.min(maxSubnetRateHostViolation, this.#metrics.minSubnetRate);
         const subnetViolationRange = Math.max(0, maxSubnetRateHostViolation - subnetViolationMin);
-        if (this.getSubnetStatus(req, false, subnetViolationRange, subnetViolationMin) === ActorStatus.Bad) {
+        if (this.getSubnetStatus(subnet, false, subnetViolationRange, subnetViolationMin) === ActorStatus.Bad) {
           return BadActorType.hostViolation;
         }
       }

--- a/src/connect.ts
+++ b/src/connect.ts
@@ -54,7 +54,7 @@ export class ConnectQOS {
     if (cluster) {
       this.#clusterSync = new ClusterSync({
         ...cluster,
-        windowMs: metricOptions.maxAge || 10000,
+        windowMs: metricOptions.maxAge ?? 10000,
       });
       this.#clusterSync.start();
     }
@@ -192,10 +192,9 @@ export class ConnectQOS {
     if (subnetStatus === ActorStatus.Bad) return BadActorType.badSubnet;
 
     // Cluster-wide checks (async-populated blocklists)
-    // Skip cluster checks for explicitly whitelisted IPs regardless of rate config
-    if (this.#clusterSync && !this.#metrics.ipWhitelist.has(ip)) {
-      if (this.#clusterSync.isBlocked('ip', ip)) return BadActorType.badIp;
-      if (this.#clusterSync.isBlocked('subnet', subnet)) return BadActorType.badSubnet;
+    if (this.#clusterSync) {
+      if (!this.#metrics.ipWhitelist.has(ip) && this.#clusterSync.isBlocked('ip', ip)) return BadActorType.badIp;
+      if (!this.#metrics.subnetWhitelist.has(subnet) && this.#clusterSync.isBlocked('subnet', subnet)) return BadActorType.badSubnet;
     }
 
     // If host is exceeding host ratio, apply per-actor rate overrides if configured

--- a/src/connect.ts
+++ b/src/connect.ts
@@ -343,7 +343,7 @@ export class ConnectQOS {
     this.#metrics.trackHost(host);
     const ip = this.resolveIp(req);
     this.#metrics.trackIp(ip);
-    this.#metrics.trackSubnet(this.resolveSubnet(req));
+    this.#metrics.trackSubnet(resolveSubnetFromIp(ip, this.#subnetMaskBits));
   }
 }
 

--- a/src/connect.ts
+++ b/src/connect.ts
@@ -150,7 +150,7 @@ export class ConnectQOS {
   shouldThrottleRequest(req: IncomingMessage|Http2ServerRequest): BadActorType|boolean {
     const host = this.resolveHost(req);
     const ip = this.resolveIp(req);
-    const subnet = this.resolveSubnet(req);
+    const subnet = resolveSubnetFromIp(ip, this.#subnetMaskBits);
     const hostStatus = this.getHostStatus(host, false); // defer tracking
     const ipStatus = this.getIpStatus(ip, false); // defer tracking
     const subnetStatus = this.getSubnetStatus(subnet, false); // defer tracking

--- a/src/connect.ts
+++ b/src/connect.ts
@@ -62,10 +62,14 @@ export class ConnectQOS {
     // we only require `toobusy.lag` feature and can ignore toobusy() via maxLag
     // toobusy.maxLag(this.#maxLag);
 
+    const userOnTrack = metricOptions.onTrack;
     this.#metrics = new Metrics({
       ...metricOptions,
-      onTrack: this.#clusterSync
-        ? (type, key) => this.#clusterSync!.recordHit(type, key)
+      onTrack: (this.#clusterSync || userOnTrack)
+        ? (type, key) => {
+          this.#clusterSync?.recordHit(type, key);
+          userOnTrack?.(type, key);
+        }
         : undefined,
     });
     this.#hostRateRange = this.#metrics.maxHostRate - this.#metrics.minHostRate;

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,3 +28,10 @@ export {
   GetMiddlewareOptions,
   DEFAULT_SUBNET_MASK_BITS
 } from './connect';
+export {
+  ClusterSync,
+  ClusterSyncOptions,
+  ClusterSyncStats,
+  ClusterRedisOptions,
+  ActorType
+} from './cluster';

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -1,5 +1,7 @@
 import LRU from 'lru-cache';
 
+export type OnTrackFn = (type: 'ip' | 'subnet' | 'host', key: string) => void;
+
 export type MetricsOptions = {
   historySize?: number;
   maxAge?: number;
@@ -15,6 +17,7 @@ export type MetricsOptions = {
   hostWhitelist?: Set<string>;
   ipWhitelist?: Set<string>;
   subnetWhitelist?: Set<string>;
+  onTrack?: OnTrackFn;
 }
 
 export enum ActorStatus {
@@ -68,7 +71,8 @@ export class Metrics {
       maxSubnetRateHostViolation = DEFAULT_MAX_SUBNET_RATE_BUSY_HOST,
       hostWhitelist = new Set(DEFAULT_HOST_WHITELIST),
       ipWhitelist = new Set(DEFAULT_IP_WHITELIST),
-      subnetWhitelist = new Set(DEFAULT_SUBNET_WHITELIST)
+      subnetWhitelist = new Set(DEFAULT_SUBNET_WHITELIST),
+      onTrack
     } = (opts || {} as MetricsOptions);
 
     if (minHostRate > maxHostRate) throw new Error(`${minHostRate} minHostRate cannot exceed ${maxHostRate} maxHostRate`)
@@ -103,6 +107,7 @@ export class Metrics {
     this.#hostWhitelist = hostWhitelist;
     this.#ipWhitelist = ipWhitelist;
     this.#subnetWhitelist = subnetWhitelist;
+    this.#onTrack = onTrack;
   }
 
   #hosts: LRU<string, CacheItem>;
@@ -129,6 +134,7 @@ export class Metrics {
   #hostWhitelist: Set<string>;
   #ipWhitelist: Set<string>;
   #subnetWhitelist: Set<string>;
+  #onTrack?: OnTrackFn;
 
   get hosts(): LRU<string, CacheItem> {
     return this.#hosts;
@@ -213,6 +219,7 @@ export class Metrics {
 
   trackHost(source: string, cache?: CacheItem): CacheItem|undefined {
     if (this.#hostWhitelist.has(source)) return;
+    this.#onTrack?.('host', source);
     if (this.#maxHostRatio) {
       // only track if ratio limits enabled (source is never whitelisted here — guarded above)
       this.#hostRatioCounts.set(source, (this.#hostRatioCounts.get(source) || 0) + 1);
@@ -254,6 +261,7 @@ export class Metrics {
 
   trackIp(source: string, cache?: CacheItem): CacheItem|undefined {
     if (this.#ipWhitelist.has(source)) return;
+    this.#onTrack?.('ip', source);
     return track(source, {
       lru: this.#ips,
       cache,
@@ -272,6 +280,7 @@ export class Metrics {
 
   trackSubnet(source: string, cache?: CacheItem): CacheItem|undefined {
     if (this.#subnetWhitelist.has(source)) return;
+    this.#onTrack?.('subnet', source);
     return track(source, {
       lru: this.#subnets,
       cache,

--- a/test/cluster.test.ts
+++ b/test/cluster.test.ts
@@ -302,6 +302,30 @@ describe('ClusterSync', () => {
       expect(onSync.mock.calls[0][0].syncDurationMs).toBeGreaterThanOrEqual(0);
     });
 
+    it('calls onError when readThresholds pipeline returns null', async () => {
+      const redis = createMockRedis();
+      redis._pipeline.exec
+        .mockResolvedValueOnce([])   // publish succeeds
+        .mockResolvedValueOnce(null); // read returns null
+      const onError = jest.fn();
+      const sync = new ClusterSync({
+        redis: { client: redis as any },
+        windowMs: 10000,
+        syncIntervalMs: 2000,
+        clusterMaxIpRate: 100,
+        onError,
+      });
+
+      sync.recordHit('ip', '1.2.3.4');
+      sync.start();
+      await sync.sync();
+      sync.stop();
+
+      expect(onError).toHaveBeenCalledWith(expect.objectContaining({ message: expect.stringContaining('null') }));
+      // publish succeeded so deltas should NOT be merged back
+      expect(sync.getAndResetDeltas('ip').size).toBe(0);
+    });
+
     it('treats null exec result as a pipeline error and merges deltas back', async () => {
       const redis = createMockRedis();
       redis._pipeline.exec.mockResolvedValue(null); // ioredis can return null

--- a/test/cluster.test.ts
+++ b/test/cluster.test.ts
@@ -164,4 +164,196 @@ describe('ClusterSync', () => {
       expect(sync.isHostViolation('example.com')).toBe(false);
     });
   });
+
+  describe('sync cycle', () => {
+    // Override fake timers to leave setImmediate real so promise resolution works
+    beforeEach(() => {
+      jest.useFakeTimers({ doNotFake: ['setImmediate', 'queueMicrotask'] });
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    it('publishDeltas sends ZINCRBY commands for accumulated IPs', async () => {
+      const redis = createMockRedis();
+      redis._pipeline.exec.mockResolvedValue([]);
+      const sync = new ClusterSync({
+        redis: { client: redis as any, keyPrefix: 'qos:' },
+        windowMs: 10000,
+        syncIntervalMs: 2000,
+        clusterMaxIpRate: 100,
+      });
+
+      sync.recordHit('ip', '1.2.3.4');
+      sync.recordHit('ip', '1.2.3.4');
+      sync.recordHit('ip', '5.6.7.8');
+
+      sync.start();
+      jest.advanceTimersByTime(2000);
+
+      // Wait for the async sync to complete
+      await new Promise(resolve => setImmediate(resolve));
+
+      expect(redis.pipeline).toHaveBeenCalled();
+      expect(redis._pipeline.zincrby).toHaveBeenCalledWith(
+        expect.stringMatching(/^qos:ip:w\d+$/),
+        2,
+        '1.2.3.4'
+      );
+      expect(redis._pipeline.zincrby).toHaveBeenCalledWith(
+        expect.stringMatching(/^qos:ip:w\d+$/),
+        1,
+        '5.6.7.8'
+      );
+      expect(redis._pipeline.exec).toHaveBeenCalled();
+      sync.stop();
+    });
+
+    it('readThresholds populates blockedIps from ZRANGEBYSCORE results', async () => {
+      const redis = createMockRedis();
+      // Mock pipeline exec to return IPs above threshold
+      redis._pipeline.exec.mockResolvedValueOnce([]) // publish
+        .mockResolvedValueOnce([ // read
+          [null, ['1.2.3.4', '5.6.7.8']], // current window IPs
+          [null, ['9.10.11.12']],          // prev window IPs
+        ]);
+      const sync = new ClusterSync({
+        redis: { client: redis as any },
+        windowMs: 10000,
+        syncIntervalMs: 2000,
+        clusterMaxIpRate: 50,
+      });
+
+      sync.recordHit('ip', 'dummy');
+      sync.start();
+      jest.advanceTimersByTime(2000);
+      await new Promise(resolve => setImmediate(resolve));
+      await new Promise(resolve => setImmediate(resolve));
+
+      expect(sync.isBlocked('ip', '1.2.3.4')).toBe(true);
+      expect(sync.isBlocked('ip', '5.6.7.8')).toBe(true);
+      expect(sync.isBlocked('ip', '9.10.11.12')).toBe(true);
+      expect(sync.isBlocked('ip', '99.99.99.99')).toBe(false);
+      sync.stop();
+    });
+
+    it('host ratio violation detected when host exceeds clusterMaxHostRatio', async () => {
+      const redis = createMockRedis();
+      // Simulate: total = 1000, host 'attack.com' = 200 (20% > 15% threshold)
+      redis._pipeline.exec.mockResolvedValueOnce([]) // publish
+        .mockResolvedValueOnce([ // read
+          [null, '1000'],                               // current total
+          [null, '0'],                                  // prev total
+          [null, ['attack.com', '200', 'good.com', '50']], // current hosts WITHSCORES
+          [null, []],                                   // prev hosts WITHSCORES
+        ]);
+      const sync = new ClusterSync({
+        redis: { client: redis as any },
+        windowMs: 10000,
+        syncIntervalMs: 2000,
+        clusterMaxHostRatio: 0.15,
+      });
+
+      sync.recordHit('host', 'attack.com');
+      sync.start();
+      jest.advanceTimersByTime(2000);
+      await new Promise(resolve => setImmediate(resolve));
+      await new Promise(resolve => setImmediate(resolve));
+
+      expect(sync.isHostViolation('attack.com')).toBe(true);
+      expect(sync.isHostViolation('good.com')).toBe(false);
+      sync.stop();
+    });
+
+    it('onError is called and deltas are retried when Redis pipeline throws', async () => {
+      const redis = createMockRedis();
+      const error = new Error('Redis connection lost');
+      redis._pipeline.exec.mockRejectedValue(error);
+      const onError = jest.fn();
+      const sync = new ClusterSync({
+        redis: { client: redis as any },
+        windowMs: 10000,
+        syncIntervalMs: 2000,
+        clusterMaxIpRate: 100,
+        onError,
+      });
+
+      sync.recordHit('ip', '1.2.3.4');
+      sync.recordHit('ip', '1.2.3.4');
+      sync.start();
+      jest.advanceTimersByTime(2000);
+      await new Promise(resolve => setImmediate(resolve));
+
+      expect(onError).toHaveBeenCalledWith(error);
+      // Deltas should be merged back for retry on next cycle
+      const retryDeltas = sync.getAndResetDeltas('ip');
+      expect(retryDeltas.get('1.2.3.4')).toBe(2);
+      sync.stop();
+    });
+
+    it('onSync is called with stats after successful sync', async () => {
+      const redis = createMockRedis();
+      redis._pipeline.exec.mockResolvedValue([]);
+      const onSync = jest.fn();
+      const sync = new ClusterSync({
+        redis: { client: redis as any },
+        windowMs: 10000,
+        syncIntervalMs: 2000,
+        clusterMaxIpRate: 100,
+        onSync,
+      });
+
+      sync.recordHit('ip', '1.2.3.4');
+      sync.start();
+      jest.advanceTimersByTime(2000);
+      await new Promise(resolve => setImmediate(resolve));
+
+      expect(onSync).toHaveBeenCalledWith(expect.objectContaining({
+        publishedDeltas: { ip: 1, subnet: 0, host: 0 },
+        blockedIps: 0,
+        blockedSubnets: 0,
+        hostViolations: 0,
+      }));
+      expect(onSync.mock.calls[0][0].syncDurationMs).toBeGreaterThanOrEqual(0);
+      sync.stop();
+    });
+
+    it('does not publish if no deltas accumulated', async () => {
+      const redis = createMockRedis();
+      const sync = new ClusterSync({
+        redis: { client: redis as any },
+        windowMs: 10000,
+        syncIntervalMs: 2000,
+        clusterMaxIpRate: 100,
+      });
+
+      sync.start();
+      jest.advanceTimersByTime(2000);
+      await new Promise(resolve => setImmediate(resolve));
+
+      // Pipeline should still be called for readThresholds, but ZINCRBY should not
+      expect(redis._pipeline.zincrby).not.toHaveBeenCalled();
+      sync.stop();
+    });
+
+    it('cleanup removes stale window keys via UNLINK', async () => {
+      const redis = createMockRedis();
+      redis._pipeline.exec.mockResolvedValue([]);
+      const sync = new ClusterSync({
+        redis: { client: redis as any, keyPrefix: 'qos:' },
+        windowMs: 10000,
+        syncIntervalMs: 2000,
+        clusterMaxIpRate: 100,
+      });
+
+      sync.recordHit('ip', '1.2.3.4');
+      sync.start();
+      jest.advanceTimersByTime(2000);
+      await new Promise(resolve => setImmediate(resolve));
+
+      expect(redis._pipeline.unlink).toHaveBeenCalled();
+      sync.stop();
+    });
+  });
 });

--- a/test/cluster.test.ts
+++ b/test/cluster.test.ts
@@ -166,15 +166,6 @@ describe('ClusterSync', () => {
   });
 
   describe('sync cycle', () => {
-    // Override fake timers to leave setImmediate real so promise resolution works
-    beforeEach(() => {
-      jest.useFakeTimers({ doNotFake: ['setImmediate', 'queueMicrotask'] });
-    });
-
-    afterEach(() => {
-      jest.useRealTimers();
-    });
-
     it('publishDeltas sends ZINCRBY commands for accumulated IPs', async () => {
       const redis = createMockRedis();
       redis._pipeline.exec.mockResolvedValue([]);
@@ -189,11 +180,7 @@ describe('ClusterSync', () => {
       sync.recordHit('ip', '1.2.3.4');
       sync.recordHit('ip', '5.6.7.8');
 
-      sync.start();
-      jest.advanceTimersByTime(2000);
-
-      // Wait for the async sync to complete
-      await new Promise(resolve => setImmediate(resolve));
+      await sync.sync();
 
       expect(redis.pipeline).toHaveBeenCalled();
       expect(redis._pipeline.zincrby).toHaveBeenCalledWith(
@@ -207,13 +194,12 @@ describe('ClusterSync', () => {
         '5.6.7.8'
       );
       expect(redis._pipeline.exec).toHaveBeenCalled();
-      sync.stop();
     });
 
     it('readThresholds populates blockedIps from ZRANGEBYSCORE results', async () => {
-      // Pin time so the interval fires exactly at a window boundary (offset = 0, prevWeight = 1.0).
-      // advanceTimersByTime(2000) brings Date.now() to 10000*100 = 1_000_000, where offset = 0.
-      jest.setSystemTime(new Date(10000 * 100 - 2000)); // 998_000ms
+      // Pin time to a window boundary (offset = 0, prevWeight = 1.0) so the
+      // sliding window weight is deterministic.
+      jest.setSystemTime(new Date(10000 * 100)); // exactly at window boundary
 
       const redis = createMockRedis();
       // threshold = 50 req/s * 10s = 500 hits. Scores of 600 exceed threshold in both windows.
@@ -232,15 +218,13 @@ describe('ClusterSync', () => {
 
       sync.recordHit('ip', 'dummy');
       sync.start();
-      jest.advanceTimersByTime(2000);
-      await new Promise(resolve => setImmediate(resolve));
-      await new Promise(resolve => setImmediate(resolve));
+      await sync.sync();
+      sync.stop();
 
       expect(sync.isBlocked('ip', '1.2.3.4')).toBe(true);
       expect(sync.isBlocked('ip', '5.6.7.8')).toBe(true);
       expect(sync.isBlocked('ip', '9.10.11.12')).toBe(true);
       expect(sync.isBlocked('ip', '99.99.99.99')).toBe(false);
-      sync.stop();
     });
 
     it('host ratio violation detected when host exceeds clusterMaxHostRatio', async () => {
@@ -262,13 +246,11 @@ describe('ClusterSync', () => {
 
       sync.recordHit('host', 'attack.com');
       sync.start();
-      jest.advanceTimersByTime(2000);
-      await new Promise(resolve => setImmediate(resolve));
-      await new Promise(resolve => setImmediate(resolve));
+      await sync.sync();
+      sync.stop();
 
       expect(sync.isHostViolation('attack.com')).toBe(true);
       expect(sync.isHostViolation('good.com')).toBe(false);
-      sync.stop();
     });
 
     it('onError is called and deltas are retried when Redis pipeline throws', async () => {
@@ -286,15 +268,12 @@ describe('ClusterSync', () => {
 
       sync.recordHit('ip', '1.2.3.4');
       sync.recordHit('ip', '1.2.3.4');
-      sync.start();
-      jest.advanceTimersByTime(2000);
-      await new Promise(resolve => setImmediate(resolve));
+      await sync.sync();
 
       expect(onError).toHaveBeenCalledWith(error);
       // Deltas should be merged back for retry on next cycle
       const retryDeltas = sync.getAndResetDeltas('ip');
       expect(retryDeltas.get('1.2.3.4')).toBe(2);
-      sync.stop();
     });
 
     it('onSync is called with stats after successful sync', async () => {
@@ -311,8 +290,8 @@ describe('ClusterSync', () => {
 
       sync.recordHit('ip', '1.2.3.4');
       sync.start();
-      jest.advanceTimersByTime(2000);
-      await new Promise(resolve => setImmediate(resolve));
+      await sync.sync();
+      sync.stop();
 
       expect(onSync).toHaveBeenCalledWith(expect.objectContaining({
         publishedDeltas: { ip: 1, subnet: 0, host: 0 },
@@ -321,7 +300,6 @@ describe('ClusterSync', () => {
         hostViolations: 0,
       }));
       expect(onSync.mock.calls[0][0].syncDurationMs).toBeGreaterThanOrEqual(0);
-      sync.stop();
     });
 
     it('does not publish if no deltas accumulated', async () => {
@@ -333,13 +311,9 @@ describe('ClusterSync', () => {
         clusterMaxIpRate: 100,
       });
 
-      sync.start();
-      jest.advanceTimersByTime(2000);
-      await new Promise(resolve => setImmediate(resolve));
+      await sync.sync();
 
-      // Pipeline should still be called for readThresholds, but ZINCRBY should not
       expect(redis._pipeline.zincrby).not.toHaveBeenCalled();
-      sync.stop();
     });
 
     it('cleanup removes stale window keys via UNLINK', async () => {
@@ -354,24 +328,14 @@ describe('ClusterSync', () => {
 
       sync.recordHit('ip', '1.2.3.4');
       sync.start();
-      jest.advanceTimersByTime(2000);
-      await new Promise(resolve => setImmediate(resolve));
+      await sync.sync();
+      sync.stop();
 
       expect(redis._pipeline.unlink).toHaveBeenCalled();
-      sync.stop();
     });
   });
 
   describe('cardinality cap', () => {
-    // Override fake timers to leave setImmediate real so promise resolution works
-    beforeEach(() => {
-      jest.useFakeTimers({ doNotFake: ['setImmediate', 'queueMicrotask'] });
-    });
-
-    afterEach(() => {
-      jest.useRealTimers();
-    });
-
     it('trims sorted sets to maxTrackedActors after publish', async () => {
       const redis = createMockRedis();
       redis._pipeline.exec.mockResolvedValue([]);
@@ -384,9 +348,7 @@ describe('ClusterSync', () => {
       });
 
       sync.recordHit('ip', '1.2.3.4');
-      sync.start();
-      jest.advanceTimersByTime(2000);
-      await new Promise(resolve => setImmediate(resolve));
+      await sync.sync();
 
       // ZREMRANGEBYRANK should be called to trim lowest-scoring members
       // keeping only top maxTrackedActors entries
@@ -395,7 +357,6 @@ describe('ClusterSync', () => {
         0,
         -1001 // removes all but top 1000
       );
-      sync.stop();
     });
   });
 });

--- a/test/cluster.test.ts
+++ b/test/cluster.test.ts
@@ -356,4 +356,41 @@ describe('ClusterSync', () => {
       sync.stop();
     });
   });
+
+  describe('cardinality cap', () => {
+    // Override fake timers to leave setImmediate real so promise resolution works
+    beforeEach(() => {
+      jest.useFakeTimers({ doNotFake: ['setImmediate', 'queueMicrotask'] });
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    it('trims sorted sets to maxTrackedActors after publish', async () => {
+      const redis = createMockRedis();
+      redis._pipeline.exec.mockResolvedValue([]);
+      const sync = new ClusterSync({
+        redis: { client: redis as any, keyPrefix: 'qos:' },
+        windowMs: 10000,
+        syncIntervalMs: 2000,
+        clusterMaxIpRate: 100,
+        maxTrackedActors: 1000,
+      });
+
+      sync.recordHit('ip', '1.2.3.4');
+      sync.start();
+      jest.advanceTimersByTime(2000);
+      await new Promise(resolve => setImmediate(resolve));
+
+      // ZREMRANGEBYRANK should be called to trim lowest-scoring members
+      // keeping only top maxTrackedActors entries
+      expect(redis._pipeline.zremrangebyrank).toHaveBeenCalledWith(
+        expect.stringMatching(/^qos:ip:w\d+$/),
+        0,
+        -1001 // removes all but top 1000
+      );
+      sync.stop();
+    });
+  });
 });

--- a/test/cluster.test.ts
+++ b/test/cluster.test.ts
@@ -211,12 +211,17 @@ describe('ClusterSync', () => {
     });
 
     it('readThresholds populates blockedIps from ZRANGEBYSCORE results', async () => {
+      // Pin time so the interval fires exactly at a window boundary (offset = 0, prevWeight = 1.0).
+      // advanceTimersByTime(2000) brings Date.now() to 10000*100 = 1_000_000, where offset = 0.
+      jest.setSystemTime(new Date(10000 * 100 - 2000)); // 998_000ms
+
       const redis = createMockRedis();
-      // Mock pipeline exec to return IPs above threshold
+      // threshold = 50 req/s * 10s = 500 hits. Scores of 600 exceed threshold in both windows.
+      // WITHSCORES format: [member, score, member, score, ...]
       redis._pipeline.exec.mockResolvedValueOnce([]) // publish
         .mockResolvedValueOnce([ // read
-          [null, ['1.2.3.4', '5.6.7.8']], // current window IPs
-          [null, ['9.10.11.12']],          // prev window IPs
+          [null, ['1.2.3.4', '600', '5.6.7.8', '600']], // current window IPs with scores
+          [null, ['9.10.11.12', '600']],                 // prev window IPs with scores
         ]);
       const sync = new ClusterSync({
         redis: { client: redis as any },

--- a/test/cluster.test.ts
+++ b/test/cluster.test.ts
@@ -1,0 +1,167 @@
+import { ClusterSync, ClusterSyncOptions } from '../src/cluster';
+
+function createMockRedis() {
+  const pipeline = {
+    zincrby: jest.fn().mockReturnThis(),
+    zrangebyscore: jest.fn().mockReturnThis(),
+    zremrangebyrank: jest.fn().mockReturnThis(),
+    incrby: jest.fn().mockReturnThis(),
+    get: jest.fn().mockReturnThis(),
+    unlink: jest.fn().mockReturnThis(),
+    exec: jest.fn().mockResolvedValue([]),
+  };
+  return {
+    pipeline: jest.fn().mockReturnValue(pipeline),
+    _pipeline: pipeline,
+  };
+}
+
+describe('ClusterSync', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  describe('constructor and lifecycle', () => {
+    it('creates instance with required options', () => {
+      const redis = createMockRedis();
+      const sync = new ClusterSync({
+        redis: { client: redis as any },
+        windowMs: 10000,
+        syncIntervalMs: 2000,
+        clusterMaxIpRate: 100,
+        clusterMaxSubnetRate: 400,
+      });
+      expect(sync).toBeInstanceOf(ClusterSync);
+      sync.stop();
+    });
+
+    it('start() begins the sync interval', () => {
+      const redis = createMockRedis();
+      const sync = new ClusterSync({
+        redis: { client: redis as any },
+        windowMs: 10000,
+        syncIntervalMs: 2000,
+        clusterMaxIpRate: 100,
+      });
+      sync.start();
+      expect(sync.isRunning).toBe(true);
+      sync.stop();
+    });
+
+    it('stop() clears the sync interval', () => {
+      const redis = createMockRedis();
+      const sync = new ClusterSync({
+        redis: { client: redis as any },
+        windowMs: 10000,
+        syncIntervalMs: 2000,
+        clusterMaxIpRate: 100,
+      });
+      sync.start();
+      sync.stop();
+      expect(sync.isRunning).toBe(false);
+    });
+
+    it('stop() is idempotent', () => {
+      const redis = createMockRedis();
+      const sync = new ClusterSync({
+        redis: { client: redis as any },
+        windowMs: 10000,
+        syncIntervalMs: 2000,
+        clusterMaxIpRate: 100,
+      });
+      sync.start();
+      sync.stop();
+      sync.stop();
+      expect(sync.isRunning).toBe(false);
+    });
+  });
+
+  describe('delta accumulation', () => {
+    it('recordHit accumulates deltas by type and key', () => {
+      const redis = createMockRedis();
+      const sync = new ClusterSync({
+        redis: { client: redis as any },
+        windowMs: 10000,
+        syncIntervalMs: 2000,
+        clusterMaxIpRate: 100,
+      });
+      sync.recordHit('ip', '1.2.3.4');
+      sync.recordHit('ip', '1.2.3.4');
+      sync.recordHit('ip', '5.6.7.8');
+      sync.recordHit('subnet', '1.2.3.0');
+      sync.recordHit('host', 'example.com');
+
+      const ipDeltas = sync.getAndResetDeltas('ip');
+      expect(ipDeltas.get('1.2.3.4')).toBe(2);
+      expect(ipDeltas.get('5.6.7.8')).toBe(1);
+
+      const subnetDeltas = sync.getAndResetDeltas('subnet');
+      expect(subnetDeltas.get('1.2.3.0')).toBe(1);
+
+      const hostDeltas = sync.getAndResetDeltas('host');
+      expect(hostDeltas.get('example.com')).toBe(1);
+    });
+
+    it('getAndResetDeltas clears accumulated deltas', () => {
+      const redis = createMockRedis();
+      const sync = new ClusterSync({
+        redis: { client: redis as any },
+        windowMs: 10000,
+        syncIntervalMs: 2000,
+        clusterMaxIpRate: 100,
+      });
+      sync.recordHit('ip', '1.2.3.4');
+      sync.getAndResetDeltas('ip');
+
+      const deltas = sync.getAndResetDeltas('ip');
+      expect(deltas.size).toBe(0);
+    });
+
+    it('recordHit respects maxTrackedActors cap', () => {
+      const redis = createMockRedis();
+      const sync = new ClusterSync({
+        redis: { client: redis as any },
+        windowMs: 10000,
+        syncIntervalMs: 2000,
+        clusterMaxIpRate: 100,
+        maxTrackedActors: 3,
+      });
+      sync.recordHit('ip', '1.1.1.1');
+      sync.recordHit('ip', '2.2.2.2');
+      sync.recordHit('ip', '3.3.3.3');
+      sync.recordHit('ip', '4.4.4.4'); // should be dropped
+
+      const deltas = sync.getAndResetDeltas('ip');
+      expect(deltas.size).toBe(3);
+      expect(deltas.has('4.4.4.4')).toBe(false);
+    });
+  });
+
+  describe('blocklist queries', () => {
+    it('isBlocked returns false initially', () => {
+      const redis = createMockRedis();
+      const sync = new ClusterSync({
+        redis: { client: redis as any },
+        windowMs: 10000,
+        syncIntervalMs: 2000,
+        clusterMaxIpRate: 100,
+      });
+      expect(sync.isBlocked('ip', '1.2.3.4')).toBe(false);
+    });
+
+    it('isHostViolation returns false initially', () => {
+      const redis = createMockRedis();
+      const sync = new ClusterSync({
+        redis: { client: redis as any },
+        windowMs: 10000,
+        syncIntervalMs: 2000,
+        clusterMaxHostRatio: 0.15,
+      });
+      expect(sync.isHostViolation('example.com')).toBe(false);
+    });
+  });
+});

--- a/test/cluster.test.ts
+++ b/test/cluster.test.ts
@@ -302,6 +302,26 @@ describe('ClusterSync', () => {
       expect(onSync.mock.calls[0][0].syncDurationMs).toBeGreaterThanOrEqual(0);
     });
 
+    it('treats null exec result as a pipeline error and merges deltas back', async () => {
+      const redis = createMockRedis();
+      redis._pipeline.exec.mockResolvedValue(null); // ioredis can return null
+      const onError = jest.fn();
+      const sync = new ClusterSync({
+        redis: { client: redis as any },
+        windowMs: 10000,
+        syncIntervalMs: 2000,
+        clusterMaxIpRate: 100,
+        onError,
+      });
+
+      sync.recordHit('ip', '1.2.3.4');
+      await sync.sync();
+
+      expect(onError).toHaveBeenCalledWith(expect.objectContaining({ message: expect.stringContaining('null') }));
+      const retryDeltas = sync.getAndResetDeltas('ip');
+      expect(retryDeltas.get('1.2.3.4')).toBe(1);
+    });
+
     it('does not publish if no deltas accumulated', async () => {
       const redis = createMockRedis();
       const sync = new ClusterSync({

--- a/test/connect.test.ts
+++ b/test/connect.test.ts
@@ -385,6 +385,26 @@ describe('shouldThrottleRequest', () => {
     } as IncomingMessage)).toEqual(false); // won't block even if bad IP since goodhost.com is whitelisted
   });
 
+  it('whitelisted host/IP still exempt when local tracking is disabled (minHostRate/minIpRate=0)', () => {
+    // When minHostRate=0, Metrics.getInfo returns Good (not Whitelisted) because minRequests=0
+    // short-circuits before the whitelist check. The guard must check whitelist sets directly.
+    const qos = new ConnectQOS({
+      maxAge: 1000,
+      minHostRate: 0, maxHostRate: 0, // host tracking disabled
+      minIpRate: 0, maxIpRate: 0,     // ip tracking disabled
+      hostWhitelist: new Set(['goodhost.com']),
+      ipWhitelist: new Set(['1.2.3.4']),
+    });
+    expect(qos.shouldThrottleRequest({
+      headers: { host: 'goodhost.com' },
+      socket: { remoteAddress: '9.9.9.9' }
+    } as IncomingMessage)).toEqual(false);
+    expect(qos.shouldThrottleRequest({
+      headers: { host: 'badhost.com' },
+      socket: { remoteAddress: '1.2.3.4' }
+    } as IncomingMessage)).toEqual(false);
+  });
+
   it('if host monitoring disabled should still be able to throttle IPs', () => {
     const qos = new ConnectQOS({ maxAge: 1000, minIpRate: 1, maxIpRate: 1, minHostRate: 0 });
     expect(qos.shouldThrottleRequest({

--- a/test/connect.test.ts
+++ b/test/connect.test.ts
@@ -574,6 +574,188 @@ describe('shouldThrottleRequest', () => {
   });
 });
 
+describe('cluster integration', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('shouldThrottleRequest returns badIp when cluster blocks the IP', () => {
+    const mockRedisClient = {
+      pipeline: jest.fn().mockReturnValue({
+        zincrby: jest.fn().mockReturnThis(),
+        zrangebyscore: jest.fn().mockReturnThis(),
+        zremrangebyrank: jest.fn().mockReturnThis(),
+        incrby: jest.fn().mockReturnThis(),
+        get: jest.fn().mockReturnThis(),
+        unlink: jest.fn().mockReturnThis(),
+        exec: jest.fn().mockResolvedValue([]),
+      }),
+    };
+    const qos = new ConnectQOS({
+      minIpRate: 0, // disable local IP limiting
+      maxAge: 1000,
+      cluster: {
+        redis: { client: mockRedisClient },
+        syncIntervalMs: 2000,
+        clusterMaxIpRate: 50,
+      },
+    });
+
+    // Manually inject a blocked IP into the cluster sync's blocklist
+    qos.clusterSync!.blockedIps.add('1.2.3.4');
+
+    const result = qos.shouldThrottleRequest({
+      headers: { host: 'example.com' },
+      socket: { remoteAddress: '1.2.3.4' }
+    } as IncomingMessage);
+
+    expect(result).toEqual(BadActorType.badIp);
+    qos.destroy();
+  });
+
+  it('shouldThrottleRequest returns badSubnet when cluster blocks the subnet', () => {
+    const mockRedisClient = {
+      pipeline: jest.fn().mockReturnValue({
+        zincrby: jest.fn().mockReturnThis(),
+        zrangebyscore: jest.fn().mockReturnThis(),
+        zremrangebyrank: jest.fn().mockReturnThis(),
+        incrby: jest.fn().mockReturnThis(),
+        get: jest.fn().mockReturnThis(),
+        unlink: jest.fn().mockReturnThis(),
+        exec: jest.fn().mockResolvedValue([]),
+      }),
+    };
+    const qos = new ConnectQOS({
+      minSubnetRate: 0, // disable local subnet limiting
+      maxAge: 1000,
+      cluster: {
+        redis: { client: mockRedisClient },
+        syncIntervalMs: 2000,
+        clusterMaxSubnetRate: 200,
+      },
+    });
+
+    qos.clusterSync!.blockedSubnets.add('1.2.3.0');
+
+    const result = qos.shouldThrottleRequest({
+      headers: { host: 'example.com' },
+      socket: { remoteAddress: '1.2.3.4' }
+    } as IncomingMessage);
+
+    expect(result).toEqual(BadActorType.badSubnet);
+    qos.destroy();
+  });
+
+  it('shouldThrottleRequest returns hostViolation when cluster detects host ratio violation', () => {
+    const mockRedisClient = {
+      pipeline: jest.fn().mockReturnValue({
+        zincrby: jest.fn().mockReturnThis(),
+        zrangebyscore: jest.fn().mockReturnThis(),
+        zremrangebyrank: jest.fn().mockReturnThis(),
+        incrby: jest.fn().mockReturnThis(),
+        get: jest.fn().mockReturnThis(),
+        unlink: jest.fn().mockReturnThis(),
+        exec: jest.fn().mockResolvedValue([]),
+      }),
+    };
+    const qos = new ConnectQOS({
+      minIpRate: 1,
+      maxIpRate: 1,
+      maxAge: 1000,
+      cluster: {
+        redis: { client: mockRedisClient },
+        syncIntervalMs: 2000,
+        clusterMaxHostRatio: 0.15,
+        clusterMaxIpRateHostViolation: 1,
+      },
+    });
+
+    qos.clusterSync!.hostViolations.add('attacked.com');
+
+    // First request: tracks the IP (history = 1)
+    expect(qos.shouldThrottleRequest({
+      headers: { host: 'attacked.com' },
+      socket: { remoteAddress: '1.2.3.4' }
+    } as IncomingMessage)).toEqual(false);
+
+    // Second request: IP rate exceeds clusterMaxIpRateHostViolation threshold
+    expect(qos.shouldThrottleRequest({
+      headers: { host: 'attacked.com' },
+      socket: { remoteAddress: '1.2.3.4' }
+    } as IncomingMessage)).toEqual(BadActorType.hostViolation);
+
+    qos.destroy();
+  });
+
+  it('whitelisted IPs are never cluster-blocked', () => {
+    const mockRedisClient = {
+      pipeline: jest.fn().mockReturnValue({
+        zincrby: jest.fn().mockReturnThis(),
+        zrangebyscore: jest.fn().mockReturnThis(),
+        zremrangebyrank: jest.fn().mockReturnThis(),
+        incrby: jest.fn().mockReturnThis(),
+        get: jest.fn().mockReturnThis(),
+        unlink: jest.fn().mockReturnThis(),
+        exec: jest.fn().mockResolvedValue([]),
+      }),
+    };
+    const qos = new ConnectQOS({
+      maxAge: 1000,
+      ipWhitelist: new Set(['1.2.3.4']),
+      cluster: {
+        redis: { client: mockRedisClient },
+        syncIntervalMs: 2000,
+        clusterMaxIpRate: 50,
+      },
+    });
+
+    qos.clusterSync!.blockedIps.add('1.2.3.4');
+
+    const result = qos.shouldThrottleRequest({
+      headers: { host: 'example.com' },
+      socket: { remoteAddress: '1.2.3.4' }
+    } as IncomingMessage);
+
+    expect(result).toEqual(false);
+    qos.destroy();
+  });
+
+  it('no cluster sync created when cluster option is not provided', () => {
+    const qos = new ConnectQOS({ maxAge: 1000 });
+    expect(qos.clusterSync).toBeUndefined();
+  });
+
+  it('destroy() stops the cluster sync', () => {
+    const mockRedisClient = {
+      pipeline: jest.fn().mockReturnValue({
+        zincrby: jest.fn().mockReturnThis(),
+        zrangebyscore: jest.fn().mockReturnThis(),
+        zremrangebyrank: jest.fn().mockReturnThis(),
+        incrby: jest.fn().mockReturnThis(),
+        get: jest.fn().mockReturnThis(),
+        unlink: jest.fn().mockReturnThis(),
+        exec: jest.fn().mockResolvedValue([]),
+      }),
+    };
+    const qos = new ConnectQOS({
+      maxAge: 1000,
+      cluster: {
+        redis: { client: mockRedisClient },
+        syncIntervalMs: 2000,
+        clusterMaxIpRate: 50,
+      },
+    });
+
+    expect(qos.clusterSync!.isRunning).toBe(true);
+    qos.destroy();
+    expect(qos.clusterSync!.isRunning).toBe(false);
+  });
+});
+
 describe('resolveHost', () => {
   it('returns self if string', () => {
     const qos = new ConnectQOS();

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -13,19 +13,33 @@ const describeIfRedis = REDIS_URL ? describe : describe.skip;
 describeIfRedis('cluster integration (requires Redis)', () => {
   let Redis: any;
   let redisClient: any;
+  let redisReady = false;
 
   beforeAll(async () => {
     Redis = require('ioredis');
-    redisClient = new Redis(REDIS_URL);
+    redisClient = new Redis(REDIS_URL, {
+      lazyConnect: true,
+      connectTimeout: 2000,
+      maxRetriesPerRequest: 0,
+      retryStrategy: () => null, // fail immediately instead of retrying
+    });
+    try {
+      await redisClient.connect();
+      redisReady = true;
+    } catch {
+      redisClient.disconnect();
+      throw new Error(`Redis not reachable at ${REDIS_URL} — start Redis to run integration tests`);
+    }
     // Clean up any leftover keys
     const keys = await redisClient.keys('qos:test:*');
     if (keys.length) await redisClient.del(...keys);
-  });
+  }, 5000);
 
   afterAll(async () => {
+    if (!redisReady || !redisClient) return;
     const keys = await redisClient.keys('qos:test:*');
     if (keys.length) await redisClient.del(...keys);
-    await redisClient.quit();
+    await redisClient.quit().catch(() => {});
   });
 
   it('two nodes detect a distributed attacker via shared counts', async () => {

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Integration test: requires a local Redis instance on localhost:6379.
+ * Run with: REDIS_URL=redis://localhost:6379 npx jest test/integration.test.ts
+ * Skip in CI if Redis is not available.
+ */
+import { ConnectQOS, BadActorType } from '../src';
+import { IncomingMessage } from 'http';
+
+const REDIS_URL = process.env.REDIS_URL;
+
+const describeIfRedis = REDIS_URL ? describe : describe.skip;
+
+describeIfRedis('cluster integration (requires Redis)', () => {
+  let Redis: any;
+  let redisClient: any;
+
+  beforeAll(async () => {
+    Redis = require('ioredis');
+    redisClient = new Redis(REDIS_URL);
+    // Clean up any leftover keys
+    const keys = await redisClient.keys('qos:test:*');
+    if (keys.length) await redisClient.del(...keys);
+  });
+
+  afterAll(async () => {
+    const keys = await redisClient.keys('qos:test:*');
+    if (keys.length) await redisClient.del(...keys);
+    await redisClient.quit();
+  });
+
+  it('two nodes detect a distributed attacker via shared counts', async () => {
+    const clusterConfig = {
+      redis: { client: redisClient, keyPrefix: 'qos:test:' },
+      syncIntervalMs: 500,
+      clusterMaxIpRate: 25,
+    };
+
+    const node1 = new ConnectQOS({
+      maxAge: 10000,
+      minIpRate: 20,
+      maxIpRate: 20,
+      minHostRate: 0,
+      cluster: clusterConfig,
+    });
+
+    const node2 = new ConnectQOS({
+      maxAge: 10000,
+      minIpRate: 20,
+      maxIpRate: 20,
+      minHostRate: 0,
+      cluster: clusterConfig,
+    });
+
+    const makeReq = (ip: string) => ({
+      headers: { host: 'target.com' },
+      socket: { remoteAddress: ip }
+    } as IncomingMessage);
+
+    // Send 150 requests to each node (below local minIpRequests of 200)
+    for (let i = 0; i < 150; i++) {
+      expect(node1.shouldThrottleRequest(makeReq('1.2.3.4'))).toBe(false);
+      expect(node2.shouldThrottleRequest(makeReq('1.2.3.4'))).toBe(false);
+    }
+
+    // Wait for sync cycle to publish + read
+    await new Promise(resolve => setTimeout(resolve, 1200));
+
+    // Now the cluster-wide count (300) exceeds cluster threshold (250)
+    // Both nodes should block this IP
+    expect(node1.shouldThrottleRequest(makeReq('1.2.3.4'))).toBe(BadActorType.badIp);
+    expect(node2.shouldThrottleRequest(makeReq('1.2.3.4'))).toBe(BadActorType.badIp);
+
+    // A different IP should still be allowed
+    expect(node1.shouldThrottleRequest(makeReq('9.9.9.9'))).toBe(false);
+
+    node1.destroy();
+    node2.destroy();
+  });
+
+  it('cluster host ratio violation detected across nodes', async () => {
+    const clusterConfig = {
+      redis: { client: redisClient, keyPrefix: 'qos:test:ratio:' },
+      syncIntervalMs: 500,
+      clusterMaxHostRatio: 0.40, // flag if host > 40% of traffic
+      clusterMaxIpRateHostViolation: 5,
+    };
+
+    const node1 = new ConnectQOS({
+      maxAge: 10000,
+      minIpRate: 5,
+      maxIpRate: 100, // high local threshold so local limiting doesn't interfere
+      minHostRate: 0,
+      cluster: clusterConfig,
+    });
+
+    const makeReq = (host: string, ip: string) => ({
+      headers: { host },
+      socket: { remoteAddress: ip }
+    } as IncomingMessage);
+
+    // Send 80% of traffic to 'attacked.com', 20% to 'other.com'
+    for (let i = 0; i < 40; i++) {
+      node1.shouldThrottleRequest(makeReq('attacked.com', `10.0.0.${i % 10}`));
+    }
+    for (let i = 0; i < 10; i++) {
+      node1.shouldThrottleRequest(makeReq('other.com', `10.1.0.${i}`));
+    }
+
+    // Wait for sync
+    await new Promise(resolve => setTimeout(resolve, 1200));
+
+    // 'attacked.com' at 80% > 40% threshold → host violation
+    expect(node1.clusterSync!.isHostViolation('attacked.com')).toBe(true);
+    expect(node1.clusterSync!.isHostViolation('other.com')).toBe(false);
+
+    node1.destroy();
+  });
+});

--- a/test/metrics.test.ts
+++ b/test/metrics.test.ts
@@ -276,6 +276,41 @@ describe('resolveSubnetFromIp', () => {
   });
 });
 
+describe('onTrack callback', () => {
+  it('fires onTrack with type and key on each trackIp call', () => {
+    const onTrack = jest.fn();
+    const metrics = new Metrics({ minIpRate: 1, maxIpRate: 10, onTrack });
+    metrics.trackIp('1.2.3.4');
+    expect(onTrack).toHaveBeenCalledWith('ip', '1.2.3.4');
+  });
+
+  it('fires onTrack with type and key on each trackSubnet call', () => {
+    const onTrack = jest.fn();
+    const metrics = new Metrics({ minSubnetRate: 1, maxSubnetRate: 10, onTrack });
+    metrics.trackSubnet('1.2.3.0');
+    expect(onTrack).toHaveBeenCalledWith('subnet', '1.2.3.0');
+  });
+
+  it('fires onTrack with type and key on each trackHost call', () => {
+    const onTrack = jest.fn();
+    const metrics = new Metrics({ minHostRate: 1, maxHostRate: 10, onTrack });
+    metrics.trackHost('example.com');
+    expect(onTrack).toHaveBeenCalledWith('host', 'example.com');
+  });
+
+  it('does not fire onTrack for whitelisted actors', () => {
+    const onTrack = jest.fn();
+    const metrics = new Metrics({ minIpRate: 1, maxIpRate: 10, ipWhitelist: new Set(['1.2.3.4']), onTrack });
+    metrics.trackIp('1.2.3.4');
+    expect(onTrack).not.toHaveBeenCalled();
+  });
+
+  it('does not throw if onTrack is not provided', () => {
+    const metrics = new Metrics({ minIpRate: 1, maxIpRate: 10 });
+    expect(() => metrics.trackIp('1.2.3.4')).not.toThrow();
+  });
+});
+
 describe('getSubnetInfo', () => {
   it('returns Good if rate limiting disabled', () => {
     const metrics = new Metrics({ minSubnetRate: 0 });


### PR DESCRIPTION
## Summary

- **New `ClusterSync` class** — background Redis sync that shares per-IP, per-subnet, and per-host hit counts across all nodes in a cluster via sorted sets. Sync is off the hot path: all throttle decisions remain local; Redis is only touched on a background interval (default: 2s).
- **Delta accumulation + retry** — each node accumulates hit counts locally between syncs and publishes deltas via `ZINCRBY`. On Redis failure, deltas are merged back into the accumulator rather than dropped.
- **Sliding window** — rate is computed from current + previous time buckets to avoid boundary spikes.
- **`onTrack` callback on `Metrics`** — fires on every `trackIp`/`trackSubnet`/`trackHost` call, even when local rate limiting is disabled. Used internally to feed `ClusterSync.recordHit()`.
- **Graceful degradation** — if Redis is unavailable, the previous blocklist stays active. The node falls back to per-node limiting until the next successful sync. No crash, no behavior change for requests already being evaluated.
- **Cardinality cap** — `ZREMRANGEBYRANK` keeps the top-N offenders per sorted set window; only runs when there are active deltas for that type.
- **`volatile-lru` safe** — QOS keys carry no TTL, so they are immune to `volatile-lru` eviction on a dedicated Valkey instance.
- **Optional peer dep** — `ioredis >= 5.0.0` added as an optional peer dependency. Not required unless cluster mode is enabled.

## How it fits the existing API

`cluster` is a new optional field on `ConnectQOSOptions`. Without it, behavior is identical to 5.6.x. With it:

```js
const qos = new ConnectQOS({
  minIpRate: 8,
  maxIpRate: 15,
  maxAge: 10000,
  cluster: {
    redis: { client: redisClient },
    syncIntervalMs: 2000,
    clusterMaxIpRate: 50,
    clusterMaxSubnetRate: 200,
    clusterMaxHostRatio: 0.20,
  }
});

process.on('SIGTERM', () => qos.destroy());
```

Call `qos.destroy()` on shutdown to stop the background interval.

## Attack patterns addressed

| Pattern | Per-node (pre-existing) | Cluster (this PR) |
|---|---|---|
| Single IP, high rate, single node | Caught | Also caught |
| Single IP, low rate per node, many nodes | **Missed** | Caught in ~2–4 s |
| Many IPs, same /24 subnet, distributed | **Missed** | Caught in ~2–4 s |
| High traffic ratio to single host | Caught (per-node hostRatio) | Caught cluster-wide |

## Test plan

- [ ] `npm test` — 114 unit tests pass, 0 failures (integration suite skips without Redis)
- [ ] `npm run test:integration` against a local Redis — distributed IP and host-ratio tests pass
- [ ] Verify `shouldThrottleRequest` returns `false` for whitelisted IPs even when cluster blocklist is populated
- [ ] Verify `destroy()` stops the sync interval (no further Redis calls after stop)
- [ ] Deploy to a staging environment and confirm `onSync` stats callback reports expected counts

🤖 Generated with [Claude Code](https://claude.com/claude-code)